### PR TITLE
Feat: Support for one time monitoring schedule (aws#4131)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 build
 src/*.egg-info
 .cache
-.coverage
+.coverage*
 sagemaker_venv*
 *.egg-info
 .tox

--- a/doc/api/utility/featuregroup_utils.rst
+++ b/doc/api/utility/featuregroup_utils.rst
@@ -1,0 +1,7 @@
+FeatureGroup Utilities
+----------------------
+
+.. automodule:: sagemaker.feature_store.feature_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/src/sagemaker/environment_variables.py
+++ b/src/sagemaker/environment_variables.py
@@ -20,6 +20,7 @@ from typing import Dict, Optional
 from sagemaker.jumpstart import utils as jumpstart_utils
 from sagemaker.jumpstart import artifacts
 from sagemaker.jumpstart.constants import DEFAULT_JUMPSTART_SAGEMAKER_SESSION
+from sagemaker.jumpstart.enums import JumpStartScriptScope
 from sagemaker.session import Session
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,8 @@ def retrieve_default(
     tolerate_deprecated_model: bool = False,
     include_aws_sdk_env_vars: bool = True,
     sagemaker_session: Session = DEFAULT_JUMPSTART_SAGEMAKER_SESSION,
+    instance_type: Optional[str] = None,
+    script: JumpStartScriptScope = JumpStartScriptScope.INFERENCE,
 ) -> Dict[str, str]:
     """Retrieves the default container environment variables for the model matching the arguments.
 
@@ -58,6 +61,10 @@ def retrieve_default(
             object, used for SageMaker interactions. If not
             specified, one is created using the default AWS configuration
             chain. (Default: sagemaker.jumpstart.constants.DEFAULT_JUMPSTART_SAGEMAKER_SESSION).
+        instance_type (str): An instance type to optionally supply in order to get environment
+            variables specific for the instance type.
+        script (JumpStartScriptScope): The JumpStart script for which to retrieve environment
+            variables.
     Returns:
         dict: The variables to use for the model.
 
@@ -78,4 +85,6 @@ def retrieve_default(
         tolerate_deprecated_model,
         include_aws_sdk_env_vars,
         sagemaker_session=sagemaker_session,
+        instance_type=instance_type,
+        script=script,
     )

--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -138,8 +138,13 @@ class AthenaQuery:
             query_execution_id=self._current_query_execution_id
         )
 
-    def as_dataframe(self) -> DataFrame:
+    def as_dataframe(self, **kwargs) -> DataFrame:
         """Download the result of the current query and load it into a DataFrame.
+
+        Args:
+            **kwargs (object): key arguments used for the method pandas.read_csv to be able to
+                    have a better tuning on data. For more info read:
+                    https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html
 
         Returns:
             A pandas DataFrame contains the query result.
@@ -161,7 +166,9 @@ class AthenaQuery:
             query_execution_id=self._current_query_execution_id,
             filename=output_filename,
         )
-        return pd.read_csv(output_filename, delimiter=",")
+
+        kwargs.pop("delimiter", None)
+        return pd.read_csv(filepath_or_buffer=output_filename, delimiter=",", **kwargs)
 
 
 @attr.s

--- a/src/sagemaker/feature_store/feature_utils.py
+++ b/src/sagemaker/feature_store/feature_utils.py
@@ -1,0 +1,341 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Utilities for working with FeatureGroups and FeatureStores."""
+from __future__ import absolute_import
+
+import re
+import logging
+
+from typing import Union
+from pathlib import Path
+
+import pandas
+import boto3
+from pandas import DataFrame, Series, read_csv
+
+from sagemaker.feature_store.feature_group import FeatureGroup
+from sagemaker.session import Session
+
+logger = logging.getLogger(__name__)
+
+
+def get_session_from_role(region: str, assume_role: str = None) -> Session:
+    """Method used to get the :class:`sagemaker.session.Session`  from a region and/or a role.
+
+    Description:
+        If invoked from a session with a role that lacks permissions, it can temporarily
+        assume another role to perform certain tasks.
+        If `assume_role` is not specified it will attempt to use the default sagemaker
+        execution role to get the session to use the Feature Store runtime client.
+
+    Args:
+        assume_role (str): (Optional) role name to be assumed
+        region (str): region name
+
+    Returns:
+        :class:`sagemaker.session.Session`
+    """
+    boto_session = boto3.Session(region_name=region)
+
+    # It will try to assume the role specified
+    if assume_role:
+        sts = boto_session.client("sts", region_name=region)
+
+        credentials = sts.assume_role(
+            RoleArn=assume_role, RoleSessionName="SagemakerExecution"
+        ).get("Credentials", {})
+
+        access_key_id = credentials.get("AccessKeyId", None)
+        secret_access_key = credentials.get("SecretAccessKey", None)
+        session_token = credentials.get("SessionToken", None)
+
+        boto_session = boto3.session.Session(
+            region_name=region,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+            aws_session_token=session_token,
+        )
+
+    sagemaker_session = Session(
+        boto_session=boto_session,
+        sagemaker_client=boto_session.client("sagemaker"),
+        sagemaker_runtime_client=boto_session.client("sagemaker-runtime"),
+        sagemaker_featurestore_runtime_client=boto_session.client(
+            service_name="sagemaker-featurestore-runtime"
+        ),
+    )
+
+    return sagemaker_session
+
+
+def get_feature_group_as_dataframe(
+    feature_group_name: str,
+    athena_bucket: str,
+    query: str = """SELECT * FROM "sagemaker_featurestore"."#{table}"
+                    WHERE is_deleted=False """,
+    role: str = None,
+    region: str = None,
+    session=None,
+    event_time_feature_name: str = None,
+    latest_ingestion: bool = True,
+    verbose: bool = True,
+    **kwargs,
+) -> DataFrame:
+    """:class:`sagemaker.feature_store.feature_group.FeatureGroup` as :class:`pandas.DataFrame`
+
+    Examples:
+        >>> from sagemaker.feature_store.feature_utils import get_feature_group_as_dataframe
+        >>>
+        >>> region = "eu-west-1"
+        >>> fg_data = get_feature_group_as_dataframe(feature_group_name="feature_group",
+        >>>                                          athena_bucket="s3://bucket/athena_queries",
+        >>>                                          region=region,
+        >>>                                          event_time_feature_name="EventTimeId"
+        >>>                                          )
+        >>>
+        >>> type(fg_data)
+        <class 'pandas.core.frame.DataFrame'>
+
+    Description:
+        Method to run an athena query over a
+        :class:`sagemaker.feature_store.feature_group.FeatureGroup` in a Feature Store
+        to retrieve its data. It needs the :class:`sagemaker.session.Session` linked to a role
+        or the region and/or role used to work with Feature Stores (it uses the module
+        `sagemaker.feature_store.feature_utils.get_session_from_role`
+        to get the session).
+
+    Args:
+        region (str): region of the target Feature Store
+        feature_group_name (str): feature store name
+        query (str): query to run. By default, it will take the latest ingest with data that
+                    wasn't deleted. If latest_ingestion is False it will take all the data
+                    in the feature group that wasn't deleted. It needs to use the keyword
+                    "#{table}" to refer to the FeatureGroup name. e.g.:
+                    'SELECT * FROM "sagemaker_featurestore"."#{table}"'
+                    It must not end by ';'.
+        athena_bucket (str): Amazon S3 bucket for running the query
+        role (str): role to be assumed to extract data from feature store. If not specified
+                    the default sagemaker execution role will be used.
+        session (str): :class:`sagemaker.session.Session`
+                        of SageMaker used to work with the feature store. Optional, with
+                        role and region parameters it will infer the session.
+        event_time_feature_name (str): eventTimeId feature. Mandatory only if the
+                                        latest ingestion is True.
+        latest_ingestion (bool): if True it will get the data only from the latest ingestion.
+                                 If False it will take whatever is specified in the query, or
+                                 if not specify it, it will get all the data that wasn't deleted.
+        verbose (bool): if True show messages, if False is silent.
+        **kwargs (object): key arguments used for the method pandas.read_csv to be able to
+                    have a better tuning on data. For more info read:
+                    https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html
+    Returns:
+        :class:`pandas.DataFrame`: dataset with the data retrieved from feature group
+    """
+
+    logger.setLevel(logging.WARNING)
+    if verbose:
+        logger.setLevel(logging.INFO)
+
+    if latest_ingestion:
+        if event_time_feature_name is not None:
+            query += str(
+                f"AND {event_time_feature_name}=(SELECT "
+                f"MAX({event_time_feature_name}) FROM "
+                '"sagemaker_featurestore"."#{table}")'
+            )
+        else:
+            exc = Exception(
+                "Argument event_time_feature_name must be specified "
+                "when using latest_ingestion=True."
+            )
+            logger.exception(exc)
+            raise exc
+
+    query += ";"
+
+    if session is not None:
+        sagemaker_session = session
+    elif region is not None:
+        sagemaker_session = get_session_from_role(region=region, assume_role=role)
+    else:
+        exc = Exception("Argument Session or role and region must be specified.")
+        logger.exception(exc)
+        raise exc
+
+    msg = f"Feature Group used: {feature_group_name}"
+    logger.info(msg)
+
+    fg = FeatureGroup(name=feature_group_name, sagemaker_session=sagemaker_session)
+
+    sample_query = fg.athena_query()
+    query_string = re.sub(r"#\{(table)\}", sample_query.table_name, query)
+
+    msg = f"Running query:\n\t{sample_query} \n\n\t-> Save on bucket {athena_bucket}\n"
+    logger.info(msg)
+
+    sample_query.run(query_string=query_string, output_location=athena_bucket)
+
+    sample_query.wait()
+
+    # run Athena query. The output is loaded to a Pandas dataframe.
+    dataset = sample_query.as_dataframe(**kwargs)
+
+    msg = f"Data shape retrieve from {feature_group_name}: {dataset.shape}"
+    logger.info(msg)
+
+    return dataset
+
+
+def _format_column_names(data: pandas.DataFrame) -> pandas.DataFrame:
+    """Formats the column names for :class:`sagemaker.feature_store.feature_group.FeatureGroup`
+
+    Description:
+        Module to format correctly the name of the columns of a DataFrame
+        to later generate the features names of a Feature Group
+
+    Args:
+        data (:class:`pandas.DataFrame`): dataframe used
+
+    Returns:
+        :class:`pandas.DataFrame`
+    """
+    data.rename(columns=lambda x: x.replace(" ", "_").replace(".", "").lower()[:62], inplace=True)
+    return data
+
+
+def _cast_object_to_string(data_frame: pandas.DataFrame) -> pandas.DataFrame:
+    """Cast properly pandas object types to strings
+
+    Description:
+        Method to convert 'object' and 'O' column dtypes of a pandas.DataFrame to
+        a valid string type recognized by Feature Groups.
+
+    Args:
+        data_frame: dataframe used
+    Returns:
+        pandas.DataFrame
+    """
+    for label in data_frame.select_dtypes(["object", "O"]).columns.tolist():
+        data_frame[label] = data_frame[label].astype("str").astype("string")
+    return data_frame
+
+
+def prepare_fg_from_dataframe_or_file(
+    dataframe_or_path: Union[str, Path, pandas.DataFrame],
+    feature_group_name: str,
+    role: str = None,
+    region: str = None,
+    session=None,
+    record_id: str = "record_id",
+    event_id: str = "data_as_of_date",
+    verbose: bool = False,
+    **kwargs,
+) -> FeatureGroup:
+    """Prepares a dataframe to create a :class:`sagemaker.feature_store.feature_group.FeatureGroup`
+
+    Description:
+        Function to prepare a :class:`pandas.DataFrame` read from a path to a csv file or pass it
+        directly to create a :class:`sagemaker.feature_store.feature_group.FeatureGroup`.
+        The path to the file needs proper dtypes, feature names and mandatory features (record_id,
+        event_id).
+        It needs the :class:`sagemaker.session.Session` linked to a role
+        or the region and/or role used to work with Feature Stores (it uses the module
+        `sagemaker.feature_store.feature_utils.get_session_from_role`
+        to get the session).
+        If record_id or event_id are not specified it will create ones
+        by default with the names 'record_id' and 'data_as_of_date'.
+
+    Args:
+        feature_group_name (str): feature group name
+        dataframe_or_path (str, Path, pandas.DataFrame) : pandas.DataFrame or path to the data
+        verbose (bool)           : True for displaying messages, False for silent method.
+        record_id (str, 'record_id'): (Optional) Feature identifier of the rows. If specified each
+                                    value of that feature has to be unique. If not specified or
+                                    record_id='record_id', then it will create a new feature from
+                                    the index of the pandas.DataFrame.
+        event_id (str)           : (Optional) Feature with the time of the creation of data rows.
+                                    If not specified it will create one with the current time
+                                    called `data_as_of_date`
+        role (str)               : role used to get the session.
+        region (str)             : region used to get the session.
+        session (str): session of SageMaker used to work with the feature store
+        **kwargs (object): key arguments used for the method pandas.read_csv to be able to
+                    have a better tuning on data. For more info read:
+                    https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html
+
+    Returns:
+        :class:`sagemaker.feature_store.feature_group.FeatureGroup`:
+            FG prepared with all the methods and definitions properly defined
+    """
+
+    logger.setLevel(logging.WARNING)
+    if verbose:
+        logger.setLevel(logging.INFO)
+
+    if isinstance(dataframe_or_path, DataFrame):
+        data = dataframe_or_path
+    elif isinstance(dataframe_or_path, str):
+        kwargs.pop("filepath_or_buffer", None)
+        data = read_csv(filepath_or_buffer=dataframe_or_path, **kwargs)
+    else:
+        exc = Exception(
+            str(
+                f"Invalid type {type(dataframe_or_path)} for "
+                "argument dataframe_or_path. \nParameter must be"
+                " of type pandas.DataFrame or string"
+            )
+        )
+        logger.exception(exc)
+        raise exc
+
+    # Formatting cols
+    data = _format_column_names(data=data)
+    data = _cast_object_to_string(data_frame=data)
+
+    if record_id == "record_id" and record_id not in data.columns:
+        data[record_id] = data.index
+
+    lg_uniq = len(data[record_id].unique())
+    lg_id = len(data[record_id])
+
+    if lg_id != lg_uniq:
+        exc = Exception(
+            str(
+                f"Record identifier {record_id} have {abs(lg_id - lg_uniq)} "
+                "duplicated rows. \nRecord identifier must be unique"
+                " in each row."
+            )
+        )
+        logger.exception(exc)
+        raise exc
+
+    if event_id not in data.columns:
+        import time
+
+        current_time_sec = int(round(time.time()))
+        data[event_id] = Series([current_time_sec] * lg_id, dtype="float64")
+
+    if session is not None:
+        sagemaker_session = session
+    elif role is not None and region is not None:
+        sagemaker_session = get_session_from_role(region=region)
+    else:
+        exc = Exception("Argument Session or role and region must be specified.")
+        logger.exception(exc)
+        raise exc
+
+    feature_group = FeatureGroup(name=feature_group_name, sagemaker_session=sagemaker_session)
+
+    feature_group.load_feature_definitions(data_frame=data)
+
+    return feature_group

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -270,20 +270,6 @@ def retrieve(
     return ECR_URI_TEMPLATE.format(registry=registry, hostname=hostname, repository=repo)
 
 
-def _get_instance_type_family(instance_type):
-    """Return the family of the instance type.
-
-    Regex matches either "ml.<family>.<size>" or "ml_<family>. If input is None
-    or there is no match, return an empty string.
-    """
-    instance_type_family = ""
-    if isinstance(instance_type, str):
-        match = re.match(r"^ml[\._]([a-z\d]+)\.?\w*$", instance_type)
-        if match is not None:
-            instance_type_family = match[1]
-    return instance_type_family
-
-
 def _get_image_tag(
     container_version,
     distribution,
@@ -297,7 +283,7 @@ def _get_image_tag(
     version,
 ):
     """Return image tag based on framework, container, and compute configuration(s)."""
-    instance_type_family = _get_instance_type_family(instance_type)
+    instance_type_family = utils.get_instance_type_family(instance_type)
     if framework in (XGBOOST_FRAMEWORK, SKLEARN_FRAMEWORK):
         if instance_type_family and final_image_scope == INFERENCE_GRAVITON:
             _validate_arg(
@@ -385,7 +371,7 @@ def _config_for_framework_and_scope(framework, image_scope, accelerator_type=Non
 
 def _validate_instance_deprecation(framework, instance_type, version):
     """Check if instance type is deprecated for a certain framework with a certain version"""
-    if _get_instance_type_family(instance_type) == "p2":
+    if utils.get_instance_type_family(instance_type) == "p2":
         if (framework == "pytorch" and Version(version) >= Version("1.13")) or (
             framework == "tensorflow" and Version(version) >= Version("2.12")
         ):
@@ -409,7 +395,7 @@ def _validate_for_suppported_frameworks_and_instance_type(framework, instance_ty
     # Validate for Graviton allowed frameowrks
     if (
         instance_type is not None
-        and _get_instance_type_family(instance_type) in GRAVITON_ALLOWED_TARGET_INSTANCE_FAMILY
+        and utils.get_instance_type_family(instance_type) in GRAVITON_ALLOWED_TARGET_INSTANCE_FAMILY
         and framework not in GRAVITON_ALLOWED_FRAMEWORKS
     ):
         _validate_framework(framework, GRAVITON_ALLOWED_FRAMEWORKS, "framework", "Graviton")
@@ -426,7 +412,7 @@ def _get_final_image_scope(framework, instance_type, image_scope):
     """Return final image scope based on provided framework and instance type."""
     if (
         framework in GRAVITON_ALLOWED_FRAMEWORKS
-        and _get_instance_type_family(instance_type) in GRAVITON_ALLOWED_TARGET_INSTANCE_FAMILY
+        and utils.get_instance_type_family(instance_type) in GRAVITON_ALLOWED_TARGET_INSTANCE_FAMILY
     ):
         return INFERENCE_GRAVITON
     if image_scope is None and framework in (XGBOOST_FRAMEWORK, SKLEARN_FRAMEWORK):
@@ -441,7 +427,7 @@ def _get_final_image_scope(framework, instance_type, image_scope):
 def _get_inference_tool(inference_tool, instance_type):
     """Extract the inference tool name from instance type."""
     if not inference_tool:
-        instance_type_family = _get_instance_type_family(instance_type)
+        instance_type_family = utils.get_instance_type_family(instance_type)
         if instance_type_family.startswith("inf") or instance_type_family.startswith("trn"):
             return "neuron"
     return inference_tool
@@ -529,7 +515,7 @@ def _processor(instance_type, available_processors, serverless_inference_config=
         processor = "neuron"
     else:
         # looks for either "ml.<family>.<size>" or "ml_<family>"
-        family = _get_instance_type_family(instance_type)
+        family = utils.get_instance_type_family(instance_type)
         if family:
             # For some frameworks, we have optimized images for specific families, e.g c5 or p3.
             # In those cases, we use the family name in the image tag. In other cases, we use
@@ -559,7 +545,7 @@ def _should_auto_select_container_version(instance_type, distribution):
     p4d = False
     if instance_type:
         # looks for either "ml.<family>.<size>" or "ml_<family>"
-        family = _get_instance_type_family(instance_type)
+        family = utils.get_instance_type_family(instance_type)
         if family:
             p4d = family == "p4d"
 

--- a/src/sagemaker/jumpstart/artifacts/environment_variables.py
+++ b/src/sagemaker/jumpstart/artifacts/environment_variables.py
@@ -34,6 +34,8 @@ def _retrieve_default_environment_variables(
     tolerate_deprecated_model: bool = False,
     include_aws_sdk_env_vars: bool = True,
     sagemaker_session: Session = DEFAULT_JUMPSTART_SAGEMAKER_SESSION,
+    instance_type: Optional[str] = None,
+    script: JumpStartScriptScope = JumpStartScriptScope.INFERENCE,
 ) -> Dict[str, str]:
     """Retrieves the inference environment variables for the model matching the given arguments.
 
@@ -59,6 +61,10 @@ def _retrieve_default_environment_variables(
             object, used for SageMaker interactions. If not
             specified, one is created using the default AWS configuration
             chain. (Default: sagemaker.jumpstart.constants.DEFAULT_JUMPSTART_SAGEMAKER_SESSION).
+        instance_type (str): An instance type to optionally supply in order to get
+            environment variables specific for the instance type.
+        script (JumpStartScriptScope): The JumpStart script for which to retrieve
+            environment variables.
     Returns:
         dict: the inference environment variables to use for the model.
     """
@@ -69,7 +75,7 @@ def _retrieve_default_environment_variables(
     model_specs = verify_model_region_and_return_specs(
         model_id=model_id,
         version=model_version,
-        scope=JumpStartScriptScope.INFERENCE,
+        scope=script,
         region=region,
         tolerate_vulnerable_model=tolerate_vulnerable_model,
         tolerate_deprecated_model=tolerate_deprecated_model,
@@ -77,9 +83,29 @@ def _retrieve_default_environment_variables(
     )
 
     default_environment_variables: Dict[str, str] = {}
-    for environment_variable in model_specs.inference_environment_variables:
-        if include_aws_sdk_env_vars or environment_variable.required_for_model_class:
-            default_environment_variables[environment_variable.name] = str(
-                environment_variable.default
+    if script == JumpStartScriptScope.INFERENCE:
+        for environment_variable in model_specs.inference_environment_variables:
+            if include_aws_sdk_env_vars or environment_variable.required_for_model_class:
+                default_environment_variables[environment_variable.name] = str(
+                    environment_variable.default
+                )
+
+    if instance_type:
+        if script == JumpStartScriptScope.INFERENCE and getattr(
+            model_specs, "hosting_instance_type_variants", None
+        ):
+            default_environment_variables.update(
+                model_specs.hosting_instance_type_variants.get_instance_specific_environment_variables(  # noqa E501  # pylint: disable=c0301
+                    instance_type
+                )
             )
+        elif script == JumpStartScriptScope.TRAINING and getattr(
+            model_specs, "training_instance_type_variants", None
+        ):
+            default_environment_variables.update(
+                model_specs.training_instance_type_variants.get_instance_specific_environment_variables(  # noqa E501  # pylint: disable=c0301
+                    instance_type
+                )
+            )
+
     return default_environment_variables

--- a/src/sagemaker/jumpstart/artifacts/image_uris.py
+++ b/src/sagemaker/jumpstart/artifacts/image_uris.py
@@ -118,10 +118,35 @@ def _retrieve_image_uri(
     )
 
     if image_scope == JumpStartScriptScope.INFERENCE:
+        hosting_instance_type_variants = model_specs.hosting_instance_type_variants
+        if hosting_instance_type_variants:
+            image_uri = hosting_instance_type_variants.get_image_uri(
+                instance_type=instance_type, region=region
+            )
+            if image_uri is not None:
+                return image_uri
         ecr_specs = model_specs.hosting_ecr_specs
+        if ecr_specs is None:
+            raise ValueError(
+                f"No inference ECR configuration found for JumpStart model ID '{model_id}' "
+                f"with {instance_type} instance type in {region}. "
+                "Please try another instance type or region."
+            )
     elif image_scope == JumpStartScriptScope.TRAINING:
+        training_instance_type_variants = model_specs.training_instance_type_variants
+        if training_instance_type_variants:
+            image_uri = training_instance_type_variants.get_image_uri(
+                instance_type=instance_type, region=region
+            )
+            if image_uri is not None:
+                return image_uri
         ecr_specs = model_specs.training_ecr_specs
-
+        if ecr_specs is None:
+            raise ValueError(
+                f"No training ECR configuration found for JumpStart model ID '{model_id}' "
+                f"with {instance_type} instance type in {region}. "
+                "Please try another instance type or region."
+            )
     if framework is not None and framework != ecr_specs.framework:
         raise ValueError(
             f"Incorrect container framework '{framework}' for JumpStart model ID '{model_id}' "

--- a/src/sagemaker/jumpstart/factory/model.py
+++ b/src/sagemaker/jumpstart/factory/model.py
@@ -286,6 +286,8 @@ def _add_env_to_kwargs(kwargs: JumpStartModelInitKwargs) -> JumpStartModelInitKw
         tolerate_deprecated_model=kwargs.tolerate_deprecated_model,
         tolerate_vulnerable_model=kwargs.tolerate_vulnerable_model,
         sagemaker_session=kwargs.sagemaker_session,
+        script=JumpStartScriptScope.INFERENCE,
+        instance_type=kwargs.instance_type,
     )
 
     for key, value in extra_env_vars.items():

--- a/src/sagemaker/model_monitor/clarify_model_monitoring.py
+++ b/src/sagemaker/model_monitor/clarify_model_monitoring.py
@@ -561,6 +561,8 @@ class ModelBiasMonitor(ClarifyModelMonitor):
         schedule_cron_expression=None,
         enable_cloudwatch_metrics=True,
         batch_transform_input=None,
+        data_analysis_start_time=None,
+        data_analysis_end_time=None,
     ):
         """Creates a monitoring schedule.
 
@@ -586,6 +588,10 @@ class ModelBiasMonitor(ClarifyModelMonitor):
                 the baselining or monitoring jobs. (default: True)
             batch_transform_input (sagemaker.model_monitor.BatchTransformInput): Inputs to run
                 the monitoring schedule on the batch transform (default: None)
+            data_analysis_start_time (str): Start time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
+            data_analysis_end_time (str): End time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
         """
         # we default ground_truth_input to None in the function signature
         # but verify they are giving here for positional argument
@@ -609,6 +615,12 @@ class ModelBiasMonitor(ClarifyModelMonitor):
             )
             _LOGGER.error(message)
             raise ValueError(message)
+
+        self._check_monitoring_schedule_cron_validity(
+            schedule_cron_expression=schedule_cron_expression,
+            data_analysis_start_time=data_analysis_start_time,
+            data_analysis_end_time=data_analysis_end_time,
+        )
 
         # create job definition
         monitor_schedule_name = self._generate_monitoring_schedule_name(
@@ -649,6 +661,8 @@ class ModelBiasMonitor(ClarifyModelMonitor):
                 monitor_schedule_name=monitor_schedule_name,
                 job_definition_name=new_job_definition_name,
                 schedule_cron_expression=schedule_cron_expression,
+                data_analysis_start_time=data_analysis_start_time,
+                data_analysis_end_time=data_analysis_end_time,
             )
             self.job_definition_name = new_job_definition_name
             self.monitoring_schedule_name = monitor_schedule_name
@@ -684,6 +698,8 @@ class ModelBiasMonitor(ClarifyModelMonitor):
         env=None,
         network_config=None,
         batch_transform_input=None,
+        data_analysis_start_time=None,
+        data_analysis_end_time=None,
     ):
         """Updates the existing monitoring schedule.
 
@@ -778,7 +794,12 @@ class ModelBiasMonitor(ClarifyModelMonitor):
         )
         self.sagemaker_session.sagemaker_client.create_model_bias_job_definition(**request_dict)
         try:
-            self._update_monitoring_schedule(new_job_definition_name, schedule_cron_expression)
+            self._update_monitoring_schedule(
+                new_job_definition_name,
+                schedule_cron_expression,
+                data_analysis_start_time=data_analysis_start_time,
+                data_analysis_end_time=data_analysis_end_time,
+            )
             self.job_definition_name = new_job_definition_name
             if role is not None:
                 self.role = role
@@ -988,6 +1009,8 @@ class ModelExplainabilityMonitor(ClarifyModelMonitor):
         schedule_cron_expression=None,
         enable_cloudwatch_metrics=True,
         batch_transform_input=None,
+        data_analysis_start_time=None,
+        data_analysis_end_time=None,
     ):
         """Creates a monitoring schedule.
 
@@ -1011,6 +1034,10 @@ class ModelExplainabilityMonitor(ClarifyModelMonitor):
                 the baselining or monitoring jobs.
             batch_transform_input (sagemaker.model_monitor.BatchTransformInput): Inputs to
             run the monitoring schedule on the batch transform
+            data_analysis_start_time (str): Start time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
+            data_analysis_end_time (str): End time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
         """
         if self.job_definition_name is not None or self.monitoring_schedule_name is not None:
             message = (
@@ -1029,6 +1056,12 @@ class ModelExplainabilityMonitor(ClarifyModelMonitor):
             )
             _LOGGER.error(message)
             raise ValueError(message)
+
+        self._check_monitoring_schedule_cron_validity(
+            schedule_cron_expression=schedule_cron_expression,
+            data_analysis_start_time=data_analysis_start_time,
+            data_analysis_end_time=data_analysis_end_time,
+        )
 
         # create job definition
         monitor_schedule_name = self._generate_monitoring_schedule_name(
@@ -1104,6 +1137,8 @@ class ModelExplainabilityMonitor(ClarifyModelMonitor):
         env=None,
         network_config=None,
         batch_transform_input=None,
+        data_analysis_start_time=None,
+        data_analysis_end_time=None,
     ):
         """Updates the existing monitoring schedule.
 
@@ -1144,6 +1179,10 @@ class ModelExplainabilityMonitor(ClarifyModelMonitor):
                 inter-container traffic, security group IDs, and subnets.
             batch_transform_input (sagemaker.model_monitor.BatchTransformInput): Inputs to
                 run the monitoring schedule on the batch transform
+            data_analysis_start_time (str): Start time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
+            data_analysis_end_time (str): End time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
         """
         valid_args = {
             arg: value for arg, value in locals().items() if arg != "self" and value is not None
@@ -1200,7 +1239,12 @@ class ModelExplainabilityMonitor(ClarifyModelMonitor):
             **request_dict
         )
         try:
-            self._update_monitoring_schedule(new_job_definition_name, schedule_cron_expression)
+            self._update_monitoring_schedule(
+                new_job_definition_name,
+                schedule_cron_expression,
+                data_analysis_start_time=data_analysis_start_time,
+                data_analysis_end_time=data_analysis_end_time,
+            )
             self.job_definition_name = new_job_definition_name
             if role is not None:
                 self.role = role

--- a/src/sagemaker/model_monitor/cron_expression_generator.py
+++ b/src/sagemaker/model_monitor/cron_expression_generator.py
@@ -75,3 +75,8 @@ class CronExpressionGenerator(object):
 
         """
         return "cron(0 {}/{} ? * * *)".format(starting_hour, hour_interval)
+
+    @staticmethod
+    def now():
+        """Returns the string used to depict the one-time schedule"""
+        return "NOW"

--- a/src/sagemaker/model_monitor/model_monitoring.py
+++ b/src/sagemaker/model_monitor/model_monitoring.py
@@ -64,6 +64,7 @@ from sagemaker.utils import (
     resolve_class_attribute_from_config,
 )
 from sagemaker.lineage._utils import get_resource_name_from_arn
+from sagemaker.model_monitor.cron_expression_generator import CronExpressionGenerator
 
 DEFAULT_REPOSITORY_NAME = "sagemaker-model-monitor-analyzer"
 
@@ -303,6 +304,8 @@ class ModelMonitor(object):
         schedule_cron_expression=None,
         batch_transform_input=None,
         arguments=None,
+        data_analysis_start_time=None,
+        data_analysis_end_time=None,
     ):
         """Creates a monitoring schedule to monitor an Amazon SageMaker Endpoint.
 
@@ -333,6 +336,10 @@ class ModelMonitor(object):
                 run the monitoring schedule on the batch transform
                 (default: None)
             arguments ([str]): A list of string arguments to be passed to a processing job.
+            data_analysis_start_time (str): Start time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
+            data_analysis_end_time (str): End time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
 
         """
         if self.monitoring_schedule_name is not None:
@@ -355,6 +362,12 @@ class ModelMonitor(object):
             )
             _LOGGER.error(message)
             raise ValueError(message)
+
+        self._check_monitoring_schedule_cron_validity(
+            schedule_cron_expression=schedule_cron_expression,
+            data_analysis_start_time=data_analysis_start_time,
+            data_analysis_end_time=data_analysis_end_time,
+        )
 
         self.monitoring_schedule_name = self._generate_monitoring_schedule_name(
             schedule_name=monitor_schedule_name
@@ -421,6 +434,8 @@ class ModelMonitor(object):
             network_config=network_config_dict,
             role_arn=self.sagemaker_session.expand_role(self.role),
             tags=self.tags,
+            data_analysis_start_time=data_analysis_start_time,
+            data_analysis_end_time=data_analysis_end_time,
         )
 
     def update_monitoring_schedule(
@@ -443,6 +458,8 @@ class ModelMonitor(object):
         role=None,
         image_uri=None,
         batch_transform_input=None,
+        data_analysis_start_time=None,
+        data_analysis_end_time=None,
     ):
         """Updates the existing monitoring schedule.
 
@@ -487,6 +504,10 @@ class ModelMonitor(object):
                 the Monitor.
             batch_transform_input (sagemaker.model_monitor.BatchTransformInput): Inputs to
                 run the monitoring schedule on the batch transform (default: None)
+            data_analysis_start_time (str): Start time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
+            data_analysis_end_time (str): End time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
 
         """
         monitoring_inputs = None
@@ -588,6 +609,8 @@ class ModelMonitor(object):
             environment=env,
             network_config=network_config_dict,
             role_arn=self.sagemaker_session.expand_role(self.role),
+            data_analysis_start_time=data_analysis_start_time,
+            data_analysis_end_time=data_analysis_end_time,
         )
 
         self._wait_for_schedule_changes_to_apply()
@@ -1481,8 +1504,41 @@ class ModelMonitor(object):
         """Type of the monitoring job."""
         raise TypeError("Subclass of {} shall define this property".format(__class__.__name__))
 
+    def _check_monitoring_schedule_cron_validity(
+        self,
+        schedule_cron_expression=None,
+        data_analysis_start_time=None,
+        data_analysis_end_time=None,
+    ):
+        """Checks if the schedule expression for the schedule is valid
+
+        Args:
+            schedule_cron_expression (str): The cron expression that dictates the frequency that
+                this job run. See sagemaker.model_monitor.CronExpressionGenerator for valid
+                expressions. Default: Daily.
+            data_analysis_start_time (str): Start time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
+            data_analysis_end_time (str): End time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
+        """
+
+        if schedule_cron_expression == CronExpressionGenerator.now() and (
+            data_analysis_start_time is None or data_analysis_end_time is None
+        ):
+            message = (
+                "Both data_analysis_start_time and data_analysis_end_time are required "
+                "for one time monitoring schedule "
+            )
+            _LOGGER.error(message)
+            raise ValueError(message)
+
     def _create_monitoring_schedule_from_job_definition(
-        self, monitor_schedule_name, job_definition_name, schedule_cron_expression=None
+        self,
+        monitor_schedule_name,
+        job_definition_name,
+        schedule_cron_expression=None,
+        data_analysis_start_time=None,
+        data_analysis_end_time=None,
     ):
         """Creates a monitoring schedule.
 
@@ -1492,9 +1548,19 @@ class ModelMonitor(object):
             schedule_cron_expression (str): The cron expression that dictates the frequency that
                 this job run. See sagemaker.model_monitor.CronExpressionGenerator for valid
                 expressions. Default: Daily.
+            data_analysis_start_time (str): Start time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
+            data_analysis_end_time (str): End time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
         """
         message = "Creating Monitoring Schedule with name: {}".format(monitor_schedule_name)
         _LOGGER.info(message)
+
+        self._check_monitoring_schedule_cron_validity(
+            schedule_cron_expression=schedule_cron_expression,
+            data_analysis_start_time=data_analysis_start_time,
+            data_analysis_end_time=data_analysis_end_time,
+        )
 
         monitoring_schedule_config = {
             "MonitoringJobDefinitionName": job_definition_name,
@@ -1502,8 +1568,18 @@ class ModelMonitor(object):
         }
         if schedule_cron_expression is not None:
             monitoring_schedule_config["ScheduleConfig"] = {
-                "ScheduleExpression": schedule_cron_expression
+                "ScheduleExpression": schedule_cron_expression,
             }
+            if data_analysis_start_time is not None:
+                monitoring_schedule_config["ScheduleConfig"][
+                    "DataAnalysisStartTime"
+                ] = data_analysis_start_time
+
+            if data_analysis_end_time is not None:
+                monitoring_schedule_config["ScheduleConfig"][
+                    "DataAnalysisEndTime"
+                ] = data_analysis_end_time
+
         all_tags = self.sagemaker_session._append_sagemaker_config_tags(
             self.tags, "{}.{}.{}".format(SAGEMAKER, MONITORING_SCHEDULE, TAGS)
         )
@@ -1556,7 +1632,13 @@ class ModelMonitor(object):
         return ProcessingInput(source=source, destination=destination, input_name=name)
 
     # noinspection PyMethodOverriding
-    def _update_monitoring_schedule(self, job_definition_name, schedule_cron_expression=None):
+    def _update_monitoring_schedule(
+        self,
+        job_definition_name,
+        schedule_cron_expression=None,
+        data_analysis_start_time=None,
+        data_analysis_end_time=None,
+    ):
         """Updates existing monitoring schedule with new job definition and/or schedule expression.
 
         Args:
@@ -1564,11 +1646,21 @@ class ModelMonitor(object):
             schedule_cron_expression (str or None): The cron expression that dictates the frequency
                 that this job run. See sagemaker.model_monitor.CronExpressionGenerator for valid
                 expressions.
+            data_analysis_start_time (str): Start time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
+            data_analysis_end_time (str): End time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
         """
         if self.job_definition_name is None or self.monitoring_schedule_name is None:
             message = "Nothing to update, please create a schedule first."
             _LOGGER.error(message)
             raise ValueError(message)
+
+        self._check_monitoring_schedule_cron_validity(
+            schedule_cron_expression=schedule_cron_expression,
+            data_analysis_start_time=data_analysis_start_time,
+            data_analysis_end_time=data_analysis_end_time,
+        )
 
         monitoring_schedule_config = {
             "MonitoringJobDefinitionName": job_definition_name,
@@ -1578,6 +1670,14 @@ class ModelMonitor(object):
             monitoring_schedule_config["ScheduleConfig"] = {
                 "ScheduleExpression": schedule_cron_expression
             }
+            if data_analysis_start_time is not None:
+                monitoring_schedule_config["ScheduleConfig"][
+                    "DataAnalysisStartTime"
+                ] = data_analysis_start_time
+            if data_analysis_end_time is not None:
+                monitoring_schedule_config["ScheduleConfig"][
+                    "DataAnalysisEndTime"
+                ] = data_analysis_end_time
 
         # Not using value from sagemaker
         # config key MONITORING_SCHEDULE_INTER_CONTAINER_ENCRYPTION_PATH here
@@ -1843,6 +1943,8 @@ class DefaultModelMonitor(ModelMonitor):
         schedule_cron_expression=None,
         enable_cloudwatch_metrics=True,
         batch_transform_input=None,
+        data_analysis_start_time=None,
+        data_analysis_end_time=None,
     ):
         """Creates a monitoring schedule to monitor an Amazon SageMaker Endpoint.
 
@@ -1878,6 +1980,10 @@ class DefaultModelMonitor(ModelMonitor):
                 the baselining or monitoring jobs.
             batch_transform_input (sagemaker.model_monitor.BatchTransformInput): Inputs to
                 run the monitoring schedule on the batch transform (default: None)
+            data_analysis_start_time (str): Start time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
+            data_analysis_end_time (str): End time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
         """
         if self.job_definition_name is not None or self.monitoring_schedule_name is not None:
             message = (
@@ -1896,6 +2002,12 @@ class DefaultModelMonitor(ModelMonitor):
             )
             _LOGGER.error(message)
             raise ValueError(message)
+
+        self._check_monitoring_schedule_cron_validity(
+            schedule_cron_expression=schedule_cron_expression,
+            data_analysis_start_time=data_analysis_start_time,
+            data_analysis_end_time=data_analysis_end_time,
+        )
 
         # create job definition
         monitor_schedule_name = self._generate_monitoring_schedule_name(
@@ -1936,6 +2048,8 @@ class DefaultModelMonitor(ModelMonitor):
                 monitor_schedule_name=monitor_schedule_name,
                 job_definition_name=new_job_definition_name,
                 schedule_cron_expression=schedule_cron_expression,
+                data_analysis_end_time=data_analysis_end_time,
+                data_analysis_start_time=data_analysis_start_time,
             )
             self.job_definition_name = new_job_definition_name
             self.monitoring_schedule_name = monitor_schedule_name
@@ -1971,6 +2085,8 @@ class DefaultModelMonitor(ModelMonitor):
         enable_cloudwatch_metrics=None,
         role=None,
         batch_transform_input=None,
+        data_analysis_start_time=None,
+        data_analysis_end_time=None,
     ):
         """Updates the existing monitoring schedule.
 
@@ -2014,6 +2130,10 @@ class DefaultModelMonitor(ModelMonitor):
             role (str): An AWS IAM role name or ARN. The Amazon SageMaker jobs use this role.
             batch_transform_input (sagemaker.model_monitor.BatchTransformInput): Inputs to
                 run the monitoring schedule on the batch transform (default: None)
+            data_analysis_start_time (str): Start time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
+            data_analysis_end_time (str): End time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
 
         """
 
@@ -2047,6 +2167,8 @@ class DefaultModelMonitor(ModelMonitor):
                 enable_cloudwatch_metrics=enable_cloudwatch_metrics,
                 role=role,
                 batch_transform_input=batch_transform_input,
+                data_analysis_start_time=data_analysis_start_time,
+                data_analysis_end_time=data_analysis_end_time,
             )
             return
 
@@ -2148,6 +2270,8 @@ class DefaultModelMonitor(ModelMonitor):
             environment=normalized_env,
             network_config=network_config_dict,
             role_arn=self.sagemaker_session.expand_role(self.role),
+            data_analysis_start_time=data_analysis_start_time,
+            data_analysis_end_time=data_analysis_end_time,
         )
 
         self._wait_for_schedule_changes_to_apply()
@@ -2172,6 +2296,8 @@ class DefaultModelMonitor(ModelMonitor):
         env=None,
         network_config=None,
         batch_transform_input=None,
+        data_analysis_start_time=None,
+        data_analysis_end_time=None,
     ):
         """Updates the existing monitoring schedule.
 
@@ -2214,6 +2340,10 @@ class DefaultModelMonitor(ModelMonitor):
                 inter-container traffic, security group IDs, and subnets.
             batch_transform_input (sagemaker.model_monitor.BatchTransformInput): Inputs to
                 run the monitoring schedule on the batch transform (default: None)
+            data_analysis_start_time (str): Start time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
+            data_analysis_end_time (str): End time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
         """
         valid_args = {
             arg: value for arg, value in locals().items() if arg != "self" and value is not None
@@ -2225,7 +2355,12 @@ class DefaultModelMonitor(ModelMonitor):
 
         # Only need to update schedule expression
         if len(valid_args) == 1 and schedule_cron_expression is not None:
-            self._update_monitoring_schedule(self.job_definition_name, schedule_cron_expression)
+            self._update_monitoring_schedule(
+                self.job_definition_name,
+                schedule_cron_expression,
+                data_analysis_start_time,
+                data_analysis_end_time,
+            )
             return
 
         existing_desc = self.sagemaker_session.describe_monitoring_schedule(
@@ -2923,6 +3058,8 @@ class ModelQualityMonitor(ModelMonitor):
         schedule_cron_expression=None,
         enable_cloudwatch_metrics=True,
         batch_transform_input=None,
+        data_analysis_start_time=None,
+        data_analysis_end_time=None,
     ):
         """Creates a monitoring schedule.
 
@@ -2953,6 +3090,10 @@ class ModelQualityMonitor(ModelMonitor):
                 the baselining or monitoring jobs.
             batch_transform_input (sagemaker.model_monitor.BatchTransformInput): Inputs to
                 run the monitoring schedule on the batch transform
+            data_analysis_start_time (str): Start time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
+            data_analysis_end_time (str): End time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
         """
         # we default below two parameters to None in the function signature
         # but verify they are giving here for positional argument
@@ -2979,6 +3120,12 @@ class ModelQualityMonitor(ModelMonitor):
             )
             _LOGGER.error(message)
             raise ValueError(message)
+
+        self._check_monitoring_schedule_cron_validity(
+            schedule_cron_expression=schedule_cron_expression,
+            data_analysis_start_time=data_analysis_start_time,
+            data_analysis_end_time=data_analysis_end_time,
+        )
 
         # create job definition
         monitor_schedule_name = self._generate_monitoring_schedule_name(
@@ -3020,6 +3167,8 @@ class ModelQualityMonitor(ModelMonitor):
                 monitor_schedule_name=monitor_schedule_name,
                 job_definition_name=new_job_definition_name,
                 schedule_cron_expression=schedule_cron_expression,
+                data_analysis_end_time=data_analysis_end_time,
+                data_analysis_start_time=data_analysis_start_time,
             )
             self.job_definition_name = new_job_definition_name
             self.monitoring_schedule_name = monitor_schedule_name
@@ -3056,6 +3205,8 @@ class ModelQualityMonitor(ModelMonitor):
         env=None,
         network_config=None,
         batch_transform_input=None,
+        data_analysis_start_time=None,
+        data_analysis_end_time=None,
     ):
         """Updates the existing monitoring schedule.
 
@@ -3100,6 +3251,10 @@ class ModelQualityMonitor(ModelMonitor):
                 inter-container traffic, security group IDs, and subnets.
             batch_transform_input (sagemaker.model_monitor.BatchTransformInput): Inputs to
                 run the monitoring schedule on the batch transform
+            data_analysis_start_time (str): Start time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
+            data_analysis_end_time (str): End time for the data analysis window
+                for the one time monitoring schedule (NOW), e.g. "-PT1H" (default: None)
         """
         valid_args = {
             arg: value for arg, value in locals().items() if arg != "self" and value is not None
@@ -3110,7 +3265,11 @@ class ModelQualityMonitor(ModelMonitor):
             return
 
         # Only need to update schedule expression
-        if len(valid_args) == 1 and schedule_cron_expression is not None:
+        if (
+            len(valid_args) == 1
+            and schedule_cron_expression is not None
+            and schedule_cron_expression != CronExpressionGenerator.now()
+        ):
             self._update_monitoring_schedule(self.job_definition_name, schedule_cron_expression)
             return
 
@@ -3155,7 +3314,12 @@ class ModelQualityMonitor(ModelMonitor):
         )
         self.sagemaker_session.sagemaker_client.create_model_quality_job_definition(**request_dict)
         try:
-            self._update_monitoring_schedule(new_job_definition_name, schedule_cron_expression)
+            self._update_monitoring_schedule(
+                new_job_definition_name,
+                schedule_cron_expression,
+                data_analysis_start_time,
+                data_analysis_end_time,
+            )
             self.job_definition_name = new_job_definition_name
             if role is not None:
                 self.role = role
@@ -3759,6 +3923,7 @@ class EndpointInput(object):
         inference_attribute=None,
         probability_attribute=None,
         probability_threshold_attribute=None,
+        exclude_features_attribute=None,
     ):
         """Initialize an ``EndpointInput`` instance.
 
@@ -3781,6 +3946,8 @@ class EndpointInput(object):
                 Only used for ModelQualityMonitor, ModelBiasMonitor and ModelExplainabilityMonitor
             probability_threshold_attribute (float): threshold to convert probabilities to binaries
                 Only used for ModelQualityMonitor, ModelBiasMonitor and ModelExplainabilityMonitor
+            exclude_features_attribute (str): Comma separated column indices of features or
+                actual feature names that needs to be excluded. (default: None)
         """
         self.endpoint_name = endpoint_name
         self.destination = destination
@@ -3792,6 +3959,7 @@ class EndpointInput(object):
         self.inference_attribute = inference_attribute
         self.probability_attribute = probability_attribute
         self.probability_threshold_attribute = probability_threshold_attribute
+        self.exclude_features_attribute = exclude_features_attribute
 
     def _to_request_dict(self):
         """Generates a request dictionary using the parameters provided to the class."""
@@ -3814,7 +3982,8 @@ class EndpointInput(object):
             endpoint_input["ProbabilityAttribute"] = self.probability_attribute
         if self.probability_threshold_attribute is not None:
             endpoint_input["ProbabilityThresholdAttribute"] = self.probability_threshold_attribute
-
+        if self.exclude_features_attribute is not None:
+            endpoint_input["ExcludeFeaturesAttribute"] = self.exclude_features_attribute
         endpoint_input_request = {"EndpointInput": endpoint_input}
         return endpoint_input_request
 
@@ -3866,6 +4035,7 @@ class BatchTransformInput(MonitoringInput):
         inference_attribute: str = None,
         probability_attribute: str = None,
         probability_threshold_attribute: str = None,
+        exclude_features_attribute: str = None,
     ):
         """Initialize a `BatchTransformInput` instance.
 
@@ -3889,6 +4059,8 @@ class BatchTransformInput(MonitoringInput):
             probability_threshold_attribute (float): threshold to convert probabilities to binaries
                 Only used for ModelQualityMonitor, ModelBiasMonitor and ModelExplainabilityMonitor
                 (default: None)
+            exclude_features_attribute (str): Comma separated column indices of features or
+                actual feature names that needs to be excluded. (default: None)
 
         """
         self.data_captured_destination_s3_uri = data_captured_destination_s3_uri
@@ -3896,6 +4068,7 @@ class BatchTransformInput(MonitoringInput):
         self.s3_input_mode = s3_input_mode
         self.s3_data_distribution_type = s3_data_distribution_type
         self.dataset_format = dataset_format
+        self.exclude_features_attribute = exclude_features_attribute
 
         super(BatchTransformInput, self).__init__(
             start_time_offset=start_time_offset,
@@ -3930,6 +4103,8 @@ class BatchTransformInput(MonitoringInput):
             batch_transform_input_data[
                 "ProbabilityThresholdAttribute"
             ] = self.probability_threshold_attribute
+        if self.exclude_features_attribute is not None:
+            batch_transform_input_data["ExcludeFeaturesAttribute"] = self.exclude_features_attribute
 
         batch_transform_input_request = {"BatchTransformInput": batch_transform_input_data}
 

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -1435,3 +1435,17 @@ def instance_supports_kms(instance_type: str) -> bool:
         ValueError: If the instance type is improperly formatted.
     """
     return volume_size_supported(instance_type)
+
+
+def get_instance_type_family(instance_type: str) -> str:
+    """Return the family of the instance type.
+
+    Regex matches either "ml.<family>.<size>" or "ml_<family>. If input is None
+    or there is no match, return an empty string.
+    """
+    instance_type_family = ""
+    if isinstance(instance_type, str):
+        match = re.match(r"^ml[\._]([a-z\d]+)\.?\w*$", instance_type)
+        if match is not None:
+            instance_type_family = match[1]
+    return instance_type_family

--- a/tests/integ/auto_ml_utils.py
+++ b/tests/integ/auto_ml_utils.py
@@ -26,7 +26,7 @@ TARGET_ATTRIBUTE_NAME = "virginica"
 
 
 def create_auto_ml_job_if_not_exist(sagemaker_session):
-    auto_ml_job_name = "python-sdk-integ-test-base-job"
+    auto_ml_job_name = "python-sdk-integ-test-base-automl-job"
 
     try:
         sagemaker_session.describe_auto_ml_job(job_name=auto_ml_job_name)

--- a/tests/integ/auto_ml_utils.py
+++ b/tests/integ/auto_ml_utils.py
@@ -25,9 +25,7 @@ TRAINING_DATA = os.path.join(DATA_DIR, "iris_training.csv")
 TARGET_ATTRIBUTE_NAME = "virginica"
 
 
-def create_auto_ml_job_if_not_exist(sagemaker_session):
-    auto_ml_job_name = "python-sdk-integ-test-base-automl-job"
-
+def create_auto_ml_job_if_not_exist(sagemaker_session, auto_ml_job_name):
     try:
         sagemaker_session.describe_auto_ml_job(job_name=auto_ml_job_name)
     except Exception as e:  # noqa: F841

--- a/tests/integ/sagemaker/feature_store/feature_processor/test_feature_processor.py
+++ b/tests/integ/sagemaker/feature_store/feature_processor/test_feature_processor.py
@@ -223,6 +223,7 @@ def test_feature_processor_transform_online_only_store_ingestion(
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_feature_processor_transform_offline_only_store_ingestion(
     sagemaker_session,
 ):

--- a/tests/integ/test_auto_ml.py
+++ b/tests/integ/test_auto_ml.py
@@ -40,7 +40,7 @@ BASE_JOB_NAME = "auto-ml"
 MODE = "ENSEMBLING"
 
 # use a succeeded AutoML job to test describe and list candidates method, otherwise tests will run too long
-AUTO_ML_JOB_NAME = "python-sdk-integ-test-base-job"
+AUTO_ML_JOB_NAME = "python-sdk-integ-test-base-automl-job"
 DEFAULT_MODEL_NAME = "python-sdk-automl"
 
 

--- a/tests/integ/test_auto_ml.py
+++ b/tests/integ/test_auto_ml.py
@@ -342,7 +342,9 @@ def test_deploy_best_candidate(sagemaker_session, cpu_instance_type, reusable_jo
 @pytest.mark.skip(
     reason="",
 )
-def test_candidate_estimator_default_rerun_and_deploy(sagemaker_session, cpu_instance_type, reusable_job_name):
+def test_candidate_estimator_default_rerun_and_deploy(
+    sagemaker_session, cpu_instance_type, reusable_job_name
+):
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
 
     auto_ml = AutoML(

--- a/tests/integ/test_auto_ml.py
+++ b/tests/integ/test_auto_ml.py
@@ -22,6 +22,7 @@ from sagemaker import AutoML, AutoMLInput, CandidateEstimator
 from sagemaker.utils import unique_name_from_base
 from tests.integ import AUTO_ML_DEFAULT_TIMEMOUT_MINUTES, DATA_DIR, auto_ml_utils
 from tests.integ.timeout import timeout
+from tests.conftest import CUSTOM_S3_OBJECT_KEY_PREFIX
 
 ROLE = "SageMakerRole"
 PREFIX = "sagemaker/beta-automl-xgboost"
@@ -198,8 +199,8 @@ def test_auto_ml_describe_auto_ml_job(sagemaker_session):
             "DataSource": {
                 "S3DataSource": {
                     "S3DataType": "S3Prefix",
-                    "S3Uri": "s3://{}/{}/input/iris_training.csv".format(
-                        sagemaker_session.default_bucket(), PREFIX
+                    "S3Uri": "s3://{}/{}/{}/input/iris_training.csv".format(
+                        sagemaker_session.default_bucket(), CUSTOM_S3_OBJECT_KEY_PREFIX, PREFIX
                     ),
                 }
             },
@@ -209,7 +210,9 @@ def test_auto_ml_describe_auto_ml_job(sagemaker_session):
         }
     ]
     expected_default_output_config = {
-        "S3OutputPath": "s3://{}/".format(sagemaker_session.default_bucket())
+        "S3OutputPath": "s3://{}/{}/".format(
+            sagemaker_session.default_bucket(), CUSTOM_S3_OBJECT_KEY_PREFIX
+        )
     }
 
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session)
@@ -236,8 +239,8 @@ def test_auto_ml_attach(sagemaker_session):
             "DataSource": {
                 "S3DataSource": {
                     "S3DataType": "S3Prefix",
-                    "S3Uri": "s3://{}/{}/input/iris_training.csv".format(
-                        sagemaker_session.default_bucket(), PREFIX
+                    "S3Uri": "s3://{}/{}/{}/input/iris_training.csv".format(
+                        sagemaker_session.default_bucket(), CUSTOM_S3_OBJECT_KEY_PREFIX, PREFIX
                     ),
                 }
             },
@@ -247,7 +250,9 @@ def test_auto_ml_attach(sagemaker_session):
         }
     ]
     expected_default_output_config = {
-        "S3OutputPath": "s3://{}/".format(sagemaker_session.default_bucket())
+        "S3OutputPath": "s3://{}/{}/".format(
+            sagemaker_session.default_bucket(), CUSTOM_S3_OBJECT_KEY_PREFIX
+        )
     }
 
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session)

--- a/tests/integ/test_auto_ml.py
+++ b/tests/integ/test_auto_ml.py
@@ -49,10 +49,10 @@ EXPECTED_DEFAULT_JOB_CONFIG = {
 
 
 # use a succeeded AutoML job to test describe and list candidates method, otherwise tests will run too long
-# reusable-job will be created once if it doesn't exist, and be reused in relevant tests.
+# test-session-job will be created once per session if it doesn't exist, and be reused in relevant tests.
 @pytest.fixture(scope="module")
-def reusable_job_name():
-    job_name = unique_name_from_base("reusable-job", max_length=32)
+def test_session_job_name():
+    job_name = unique_name_from_base("test-session-job", max_length=32)
     return job_name
 
 
@@ -199,7 +199,7 @@ def test_auto_ml_invalid_target_attribute(sagemaker_session):
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
-def test_auto_ml_describe_auto_ml_job(sagemaker_session, reusable_job_name):
+def test_auto_ml_describe_auto_ml_job(sagemaker_session, test_session_job_name):
     expected_default_input_config = [
         {
             "DataSource": {
@@ -221,13 +221,13 @@ def test_auto_ml_describe_auto_ml_job(sagemaker_session, reusable_job_name):
         )
     }
 
-    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
+    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, test_session_job_name)
     auto_ml = AutoML(
         role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
     )
 
-    desc = auto_ml.describe_auto_ml_job(job_name=reusable_job_name)
-    assert desc["AutoMLJobName"] == reusable_job_name
+    desc = auto_ml.describe_auto_ml_job(job_name=test_session_job_name)
+    assert desc["AutoMLJobName"] == test_session_job_name
     assert desc["AutoMLJobStatus"] == "Completed"
     assert isinstance(desc["BestCandidate"], dict)
     assert desc["InputDataConfig"] == expected_default_input_config
@@ -239,7 +239,7 @@ def test_auto_ml_describe_auto_ml_job(sagemaker_session, reusable_job_name):
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
-def test_auto_ml_attach(sagemaker_session, reusable_job_name):
+def test_auto_ml_attach(sagemaker_session, test_session_job_name):
     expected_default_input_config = [
         {
             "DataSource": {
@@ -261,13 +261,13 @@ def test_auto_ml_attach(sagemaker_session, reusable_job_name):
         )
     }
 
-    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
+    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, test_session_job_name)
 
     attached_automl_job = AutoML.attach(
-        auto_ml_job_name=reusable_job_name, sagemaker_session=sagemaker_session
+        auto_ml_job_name=test_session_job_name, sagemaker_session=sagemaker_session
     )
     attached_desc = attached_automl_job.describe_auto_ml_job()
-    assert attached_desc["AutoMLJobName"] == reusable_job_name
+    assert attached_desc["AutoMLJobName"] == test_session_job_name
     assert attached_desc["AutoMLJobStatus"] == "Completed"
     assert isinstance(attached_desc["BestCandidate"], dict)
     assert attached_desc["InputDataConfig"] == expected_default_input_config
@@ -279,14 +279,14 @@ def test_auto_ml_attach(sagemaker_session, reusable_job_name):
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
-def test_list_candidates(sagemaker_session, reusable_job_name):
-    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
+def test_list_candidates(sagemaker_session, test_session_job_name):
+    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, test_session_job_name)
 
     auto_ml = AutoML(
         role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
     )
 
-    candidates = auto_ml.list_candidates(job_name=reusable_job_name)
+    candidates = auto_ml.list_candidates(job_name=test_session_job_name)
     assert len(candidates) == 3
 
 
@@ -294,13 +294,13 @@ def test_list_candidates(sagemaker_session, reusable_job_name):
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
-def test_best_candidate(sagemaker_session, reusable_job_name):
-    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
+def test_best_candidate(sagemaker_session, test_session_job_name):
+    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, test_session_job_name)
 
     auto_ml = AutoML(
         role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
     )
-    best_candidate = auto_ml.best_candidate(job_name=reusable_job_name)
+    best_candidate = auto_ml.best_candidate(job_name=test_session_job_name)
     assert len(best_candidate["InferenceContainers"]) == 3
     assert len(best_candidate["CandidateSteps"]) == 4
     assert best_candidate["CandidateStatus"] == "Completed"
@@ -311,13 +311,13 @@ def test_best_candidate(sagemaker_session, reusable_job_name):
     reason="AutoML is not supported in the region yet.",
 )
 @pytest.mark.release
-def test_deploy_best_candidate(sagemaker_session, cpu_instance_type, reusable_job_name):
-    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
+def test_deploy_best_candidate(sagemaker_session, cpu_instance_type, test_session_job_name):
+    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, test_session_job_name)
 
     auto_ml = AutoML(
         role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
     )
-    best_candidate = auto_ml.best_candidate(job_name=reusable_job_name)
+    best_candidate = auto_ml.best_candidate(job_name=test_session_job_name)
     endpoint_name = unique_name_from_base("sagemaker-auto-ml-best-candidate-test")
 
     with timeout(minutes=AUTO_ML_DEFAULT_TIMEMOUT_MINUTES):
@@ -343,15 +343,15 @@ def test_deploy_best_candidate(sagemaker_session, cpu_instance_type, reusable_jo
     reason="",
 )
 def test_candidate_estimator_default_rerun_and_deploy(
-    sagemaker_session, cpu_instance_type, reusable_job_name
+    sagemaker_session, cpu_instance_type, test_session_job_name
 ):
-    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
+    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, test_session_job_name)
 
     auto_ml = AutoML(
         role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
     )
 
-    candidates = auto_ml.list_candidates(job_name=reusable_job_name)
+    candidates = auto_ml.list_candidates(job_name=test_session_job_name)
     candidate = candidates[1]
 
     candidate_estimator = CandidateEstimator(candidate, sagemaker_session)
@@ -377,13 +377,13 @@ def test_candidate_estimator_default_rerun_and_deploy(
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
-def test_candidate_estimator_get_steps(sagemaker_session, reusable_job_name):
-    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
+def test_candidate_estimator_get_steps(sagemaker_session, test_session_job_name):
+    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, test_session_job_name)
 
     auto_ml = AutoML(
         role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
     )
-    candidates = auto_ml.list_candidates(job_name=reusable_job_name)
+    candidates = auto_ml.list_candidates(job_name=test_session_job_name)
     candidate = candidates[1]
 
     candidate_estimator = CandidateEstimator(candidate, sagemaker_session)

--- a/tests/integ/test_feature_store.py
+++ b/tests/integ/test_feature_store.py
@@ -12,9 +12,9 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import datetime
 import json
 import time
-import datetime
 import dateutil.parser as date_parser
 from contextlib import contextmanager
 
@@ -24,6 +24,7 @@ import pandas as pd
 import pytest
 from pandas import DataFrame
 
+from sagemaker.feature_store.feature_utils import get_feature_group_as_dataframe
 from sagemaker.feature_store.feature_definition import FractionalFeatureDefinition
 from sagemaker.feature_store.feature_group import FeatureGroup
 from sagemaker.feature_store.feature_store import FeatureStore
@@ -1346,6 +1347,82 @@ def _wait_for_feature_group_update(feature_group: FeatureGroup):
         print(feature_group.describe())
         raise RuntimeError(f"Failed to update feature group {feature_group.name}")
     print(f"FeatureGroup {feature_group.name} successfully updated.")
+
+
+def test_get_feature_group_with_region(
+    feature_store_session,
+    region_name,
+    role,
+    feature_group_name,
+    offline_store_s3_uri,
+    pandas_data_frame,
+):
+    feature_group = FeatureGroup(name=feature_group_name, sagemaker_session=feature_store_session)
+    feature_group.load_feature_definitions(data_frame=pandas_data_frame)
+
+    with cleanup_feature_group(feature_group):
+        output = feature_group.create(
+            s3_uri=offline_store_s3_uri,
+            record_identifier_name="feature1",
+            event_time_feature_name="feature3",
+            role_arn=role,
+            enable_online_store=True,
+        )
+        _wait_for_feature_group_create(feature_group)
+
+        feature_group.ingest(
+            data_frame=pandas_data_frame, max_workers=3, max_processes=2, wait=True
+        )
+
+        dataset = get_feature_group_as_dataframe(
+            feature_group_name=feature_group_name,
+            region=str(region_name),
+            event_time_feature_name="feature3",
+            latest_ingestion=True,
+            athena_bucket=f"{offline_store_s3_uri}/query",
+            verbose=False,
+        )
+
+        assert isinstance(dataset, DataFrame)
+    assert output["FeatureGroupArn"].endswith(f"feature-group/{feature_group_name}")
+
+
+def test_get_feature_group_with_session(
+    feature_store_session,
+    role,
+    feature_group_name,
+    offline_store_s3_uri,
+    pandas_data_frame,
+):
+    feature_group = FeatureGroup(name=feature_group_name, sagemaker_session=feature_store_session)
+    feature_group.load_feature_definitions(data_frame=pandas_data_frame)
+
+    with cleanup_feature_group(feature_group):
+        output = feature_group.create(
+            s3_uri=offline_store_s3_uri,
+            record_identifier_name="feature1",
+            event_time_feature_name="feature3",
+            role_arn=role,
+            enable_online_store=True,
+        )
+        _wait_for_feature_group_create(feature_group)
+
+        feature_group.ingest(
+            data_frame=pandas_data_frame, max_workers=3, max_processes=2, wait=True
+        )
+
+        dataset = get_feature_group_as_dataframe(
+            feature_group_name=feature_group_name,
+            session=feature_store_session,
+            event_time_feature_name="feature3",
+            latest_ingestion=True,
+            athena_bucket=f"{offline_store_s3_uri}/query",
+            verbose=False,
+            low_memory=False,
+        )  # Using kwargs to pass a parameter to pandas.read_csv
+
+        assert isinstance(dataset, DataFrame)
+    assert output["FeatureGroupArn"].endswith(f"feature-group/{feature_group_name}")
 
 
 @contextmanager

--- a/tests/integ/test_inference_recommender.py
+++ b/tests/integ/test_inference_recommender.py
@@ -206,7 +206,7 @@ def default_right_sized_unregistered_model(sagemaker_session, cpu_instance_type)
                 ir_job_name,
             )
         except Exception:
-            sagemaker_session.delete_model(ModelName=sklearn_model.name)
+            sagemaker_session.delete_model(model_name=sklearn_model.name)
 
 
 @pytest.fixture(scope="module")
@@ -261,7 +261,7 @@ def advanced_right_sized_unregistered_model(sagemaker_session, cpu_instance_type
             )
 
         except Exception:
-            sagemaker_session.delete_model(ModelName=sklearn_model.name)
+            sagemaker_session.delete_model(model_name=sklearn_model.name)
 
 
 @pytest.fixture(scope="module")
@@ -300,7 +300,7 @@ def default_right_sized_unregistered_base_model(sagemaker_session, cpu_instance_
                 ir_job_name,
             )
         except Exception:
-            sagemaker_session.delete_model(ModelName=model.name)
+            sagemaker_session.delete_model(model_name=model.name)
 
 
 @pytest.fixture(scope="module")
@@ -328,6 +328,7 @@ def created_base_model(sagemaker_session, cpu_instance_type):
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_default_right_size_and_deploy_registered_model_sklearn(
     default_right_sized_model, sagemaker_session
 ):
@@ -350,6 +351,7 @@ def test_default_right_size_and_deploy_registered_model_sklearn(
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_default_right_size_and_deploy_unregistered_model_sklearn(
     default_right_sized_unregistered_model, sagemaker_session
 ):
@@ -372,6 +374,7 @@ def test_default_right_size_and_deploy_unregistered_model_sklearn(
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_default_right_size_and_deploy_unregistered_base_model(
     default_right_sized_unregistered_base_model, sagemaker_session
 ):
@@ -394,6 +397,7 @@ def test_default_right_size_and_deploy_unregistered_base_model(
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_advanced_right_size_and_deploy_unregistered_model_sklearn(
     advanced_right_sized_unregistered_model, sagemaker_session
 ):
@@ -416,6 +420,7 @@ def test_advanced_right_size_and_deploy_unregistered_model_sklearn(
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_advanced_right_size_and_deploy_registered_model_sklearn(
     advanced_right_sized_model, sagemaker_session
 ):
@@ -446,6 +451,7 @@ def test_advanced_right_size_and_deploy_registered_model_sklearn(
 # TODO when we've added support for inference_recommendation_id
 # then add tests to test Framework models
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_deploy_inference_recommendation_id_with_registered_model_sklearn(
     default_right_sized_model, sagemaker_session
 ):
@@ -480,6 +486,7 @@ def test_deploy_inference_recommendation_id_with_registered_model_sklearn(
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_deploy_deployment_recommendation_id_with_model(created_base_model, sagemaker_session):
     with timeout(minutes=20):
         try:

--- a/tests/unit/sagemaker/feature_store/test_feature_group.py
+++ b/tests/unit/sagemaker/feature_store/test_feature_group.py
@@ -752,7 +752,7 @@ def test_athena_query_as_dataframe(read_csv, sagemaker_session_mock, query):
         query_execution_id="query_id",
         filename="tmp/query_id.csv",
     )
-    read_csv.assert_called_with("tmp/query_id.csv", delimiter=",")
+    read_csv.assert_called_with(filepath_or_buffer="tmp/query_id.csv", delimiter=",")
 
 
 @patch("tempfile.gettempdir", Mock(return_value="tmp"))

--- a/tests/unit/sagemaker/feature_store/test_feature_utils.py
+++ b/tests/unit/sagemaker/feature_store/test_feature_utils.py
@@ -1,0 +1,125 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+# language governing permissions and limitations under the License.
+"""Test for Feature Group Utils"""
+from __future__ import absolute_import
+
+import pandas as pd
+import pytest
+from mock import Mock
+
+from sagemaker.feature_store.feature_utils import (
+    _cast_object_to_string,
+    prepare_fg_from_dataframe_or_file,
+    get_feature_group_as_dataframe,
+)
+from sagemaker.feature_store.feature_definition import (
+    FeatureTypeEnum,
+)
+from sagemaker.feature_store.feature_group import (
+    FeatureGroup,
+)
+
+
+class PicklableMock(Mock):
+    """Mock class use for tests"""
+
+    def __reduce__(self):
+        """Method from class Mock"""
+        return (Mock, ())
+
+
+@pytest.fixture
+def sagemaker_session_mock():
+    """Fixture Mock class"""
+    return Mock()
+
+
+def test_convert_unsupported_types_to_supported(sagemaker_session_mock):
+    feature_group = FeatureGroup(name="FailedGroup", sagemaker_session=sagemaker_session_mock)
+    df = pd.DataFrame(
+        {
+            "float": pd.Series([2.0], dtype="float64"),
+            "int": pd.Series([2], dtype="int64"),
+            "object": pd.Series(["f1"], dtype="object"),
+        }
+    )
+    # Converting object or O type to string
+    df = _cast_object_to_string(data_frame=df)
+
+    feature_definitions = feature_group.load_feature_definitions(data_frame=df)
+    types = [fd.feature_type for fd in feature_definitions]
+
+    assert types == [
+        FeatureTypeEnum.FRACTIONAL,
+        FeatureTypeEnum.INTEGRAL,
+        FeatureTypeEnum.STRING,
+    ]
+
+
+def test_prepare_fg_from_dataframe(sagemaker_session_mock):
+    very_long_name = "long" * 20
+    df = pd.DataFrame(
+        {
+            "space feature": pd.Series([2.0], dtype="float64"),
+            "dot.feature": pd.Series([2], dtype="int64"),
+            very_long_name: pd.Series(["f1"], dtype="string"),
+        }
+    )
+
+    feature_group = prepare_fg_from_dataframe_or_file(
+        dataframe_or_path=df,
+        session=sagemaker_session_mock,
+        feature_group_name="testFG",
+    )
+
+    names = [fd.feature_name for fd in feature_group.feature_definitions]
+    types = [fd.feature_type for fd in feature_group.feature_definitions]
+
+    assert names == [
+        "space_feature",
+        "dotfeature",
+        very_long_name[:62],
+        "record_id",
+        "data_as_of_date",
+    ]
+    assert types == [
+        FeatureTypeEnum.FRACTIONAL,
+        FeatureTypeEnum.INTEGRAL,
+        FeatureTypeEnum.STRING,
+        FeatureTypeEnum.INTEGRAL,
+        FeatureTypeEnum.FRACTIONAL,
+    ]
+
+
+def test_get_fg_latest_without_eventid(sagemaker_session_mock):
+    with pytest.raises(Exception):
+        get_feature_group_as_dataframe(
+            session=sagemaker_session_mock,
+            feature_group_name="testFG",
+            athena_bucket="s3://test",
+            latest_ingestion=True,
+            event_time_feature_name=None,
+        )
+
+
+def test_get_fg_without_sess_role_region(sagemaker_session_mock):
+    with pytest.raises(Exception):
+        get_feature_group_as_dataframe(
+            session=None,
+            region=None,
+            role=None,
+            feature_group_name="testFG",
+            athena_bucket="s3://test",
+            latest_ingestion=False,
+        )

--- a/tests/unit/sagemaker/image_uris/jumpstart/test_variants.py
+++ b/tests/unit/sagemaker/image_uris/jumpstart/test_variants.py
@@ -1,0 +1,87 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+from mock.mock import patch
+import pytest
+
+from sagemaker import image_uris
+from sagemaker.jumpstart.utils import verify_model_region_and_return_specs
+
+from tests.unit.sagemaker.jumpstart.utils import get_special_model_spec
+
+
+@patch("sagemaker.jumpstart.artifacts.image_uris.verify_model_region_and_return_specs")
+@patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+def test_jumpstart_variants_image_uri(
+    patched_get_model_specs, patched_verify_model_region_and_return_specs
+):
+
+    patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
+    patched_get_model_specs.side_effect = get_special_model_spec
+
+    assert (
+        "763104351884.dkr.ecr.us-west-2.amazonaws.com/"
+        "huggingface-pytorch-inference:1.13.1-transformers4.26.0-gpu-py39-cu117-ubuntu20.04"
+        == image_uris.retrieve(
+            framework=None,
+            region="us-west-2",
+            image_scope="inference",
+            model_id="variant-model",
+            model_version="*",
+            instance_type="ml.p2.xlarge",
+        )
+    )
+
+    assert "867930986793.dkr.us-west-2.amazonaws.com/cpu-blah" == image_uris.retrieve(
+        framework=None,
+        region="us-west-2",
+        image_scope="inference",
+        model_id="variant-model",
+        model_version="*",
+        instance_type="ml.c2.xlarge",
+    )
+
+    assert (
+        "763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-inference:1.5.0-cpu-py3"
+        == image_uris.retrieve(
+            framework=None,
+            region="us-west-2",
+            image_scope="inference",
+            model_id="variant-model",
+            model_version="*",
+            instance_type="ml.c200000.xlarge",
+        )
+    )
+
+    with pytest.raises(ValueError):
+        image_uris.retrieve(
+            framework=None,
+            region="us-west-29",
+            image_scope="inference",
+            model_id="variant-model",
+            model_version="*",
+            instance_type="ml.c2.xlarge",
+        )
+
+    assert (
+        "763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-training:1.5.0-gpu-py3"
+        == image_uris.retrieve(
+            framework=None,
+            region="us-west-2",
+            image_scope="training",
+            model_id="variant-model",
+            model_version="*",
+            instance_type="ml.g4dn.2xlarge",
+        )
+    )

--- a/tests/unit/sagemaker/jumpstart/constants.py
+++ b/tests/unit/sagemaker/jumpstart/constants.py
@@ -14,6 +14,365 @@ from __future__ import absolute_import
 
 
 SPECIAL_MODEL_SPECS_DICT = {
+    "env-var-variant-model": {
+        "model_id": "huggingface-llm-falcon-180b-bf16",
+        "url": "https://huggingface.co/tiiuae/falcon-180B",
+        "version": "1.0.0",
+        "min_sdk_version": "2.175.0",
+        "training_supported": False,
+        "incremental_training_supported": False,
+        "hosting_ecr_specs": {
+            "framework": "huggingface-llm",
+            "framework_version": "0.9.3",
+            "py_version": "py39",
+            "huggingface_transformers_version": "4.29.2",
+        },
+        "hosting_artifact_key": "huggingface-infer/infer-huggingface-llm-falcon-180b-bf16.tar.gz",
+        "hosting_script_key": "source-directory-tarballs/huggingface/inference/llm/v1.0.1/sourcedir.tar.gz",
+        "hosting_prepacked_artifact_key": "huggingface-infer/prepack/v1.0.1/infer-prepack"
+        "-huggingface-llm-falcon-180b-bf16.tar.gz",
+        "hosting_prepacked_artifact_version": "1.0.1",
+        "hosting_use_script_uri": False,
+        "inference_vulnerable": False,
+        "inference_dependencies": [],
+        "inference_vulnerabilities": [],
+        "training_vulnerable": False,
+        "training_dependencies": [],
+        "training_vulnerabilities": [],
+        "deprecated": False,
+        "inference_environment_variables": [
+            {
+                "name": "SAGEMAKER_PROGRAM",
+                "type": "text",
+                "default": "inference.py",
+                "scope": "container",
+                "required_for_model_class": True,
+            },
+            {
+                "name": "SAGEMAKER_SUBMIT_DIRECTORY",
+                "type": "text",
+                "default": "/opt/ml/model/code",
+                "scope": "container",
+                "required_for_model_class": False,
+            },
+            {
+                "name": "SAGEMAKER_CONTAINER_LOG_LEVEL",
+                "type": "text",
+                "default": "20",
+                "scope": "container",
+                "required_for_model_class": False,
+            },
+            {
+                "name": "SAGEMAKER_MODEL_SERVER_TIMEOUT",
+                "type": "text",
+                "default": "3600",
+                "scope": "container",
+                "required_for_model_class": False,
+            },
+            {
+                "name": "ENDPOINT_SERVER_TIMEOUT",
+                "type": "int",
+                "default": 3600,
+                "scope": "container",
+                "required_for_model_class": True,
+            },
+            {
+                "name": "MODEL_CACHE_ROOT",
+                "type": "text",
+                "default": "/opt/ml/model",
+                "scope": "container",
+                "required_for_model_class": True,
+            },
+            {
+                "name": "SAGEMAKER_ENV",
+                "type": "text",
+                "default": "1",
+                "scope": "container",
+                "required_for_model_class": True,
+            },
+            {
+                "name": "HF_MODEL_ID",
+                "type": "text",
+                "default": "/opt/ml/model",
+                "scope": "container",
+                "required_for_model_class": True,
+            },
+            {
+                "name": "SM_NUM_GPUS",
+                "type": "text",
+                "default": "8",
+                "scope": "container",
+                "required_for_model_class": True,
+            },
+            {
+                "name": "MAX_INPUT_LENGTH",
+                "type": "text",
+                "default": "1024",
+                "scope": "container",
+                "required_for_model_class": True,
+            },
+            {
+                "name": "MAX_TOTAL_TOKENS",
+                "type": "text",
+                "default": "2048",
+                "scope": "container",
+                "required_for_model_class": True,
+            },
+            {
+                "name": "SAGEMAKER_MODEL_SERVER_WORKERS",
+                "type": "int",
+                "default": 1,
+                "scope": "container",
+                "required_for_model_class": True,
+            },
+        ],
+        "metrics": [],
+        "default_inference_instance_type": "ml.p4de.24xlarge",
+        "supported_inference_instance_types": ["ml.p4de.24xlarge"],
+        "model_kwargs": {},
+        "deploy_kwargs": {
+            "model_data_download_timeout": 3600,
+            "container_startup_health_check_timeout": 3600,
+        },
+        "predictor_specs": {
+            "supported_content_types": ["application/json"],
+            "supported_accept_types": ["application/json"],
+            "default_content_type": "application/json",
+            "default_accept_type": "application/json",
+        },
+        "inference_volume_size": 512,
+        "inference_enable_network_isolation": True,
+        "validation_supported": False,
+        "fine_tuning_supported": False,
+        "resource_name_base": "hf-llm-falcon-180b-bf16",
+        "hosting_instance_type_variants": {
+            "regional_aliases": {
+                "us-west-2": {
+                    "gpu_image_uri": "763104351884.dkr.ecr.us-west-2.amazonaws.com/"
+                    "huggingface-pytorch-inference:1.13.1-transformers4.26.0-gpu-py39-cu117-ubuntu20.04",
+                    "cpu_image_uri": "867930986793.dkr.us-west-2.amazonaws.com/cpu-blah",
+                }
+            },
+            "variants": {
+                "g4dn": {"regional_properties": {"image_uri": "$gpu_ecr_uri_1"}},
+                "g5": {"regional_properties": {"image_uri": "$gpu_ecr_uri_1"}},
+                "local_gpu": {"regional_properties": {"image_uri": "$gpu_ecr_uri_1"}},
+                "p2": {"regional_properties": {"image_uri": "$gpu_ecr_uri_1"}},
+                "p3": {"regional_properties": {"image_uri": "$gpu_ecr_uri_1"}},
+                "p3dn": {"regional_properties": {"image_uri": "$gpu_ecr_uri_1"}},
+                "p4d": {"regional_properties": {"image_uri": "$gpu_ecr_uri_1"}},
+                "p4de": {"regional_properties": {"image_uri": "$gpu_ecr_uri_1"}},
+                "p5": {"regional_properties": {"image_uri": "$gpu_ecr_uri_1"}},
+                "ml.g5.48xlarge": {"properties": {"environment_variables": {"SM_NUM_GPUS": "80"}}},
+                "ml.p4d.24xlarge": {
+                    "properties": {
+                        "environment_variables": {
+                            "YODEL": "NACEREMA",
+                        }
+                    }
+                },
+            },
+        },
+    },
+    "variant-model": {
+        "model_id": "pytorch-ic-mobilenet-v2",
+        "url": "https://pytorch.org/hub/pytorch_vision_mobilenet_v2/",
+        "version": "1.0.0",
+        "min_sdk_version": "2.49.0",
+        "training_supported": True,
+        "incremental_training_supported": True,
+        "hosting_ecr_specs": {
+            "framework": "pytorch",
+            "framework_version": "1.5.0",
+            "py_version": "py3",
+        },
+        "hosting_instance_type_variants": {
+            "regional_aliases": {
+                "us-west-2": {
+                    "gpu_image_uri": "763104351884.dkr.ecr.us-west-2.amazonaws.com/"
+                    "huggingface-pytorch-inference:1.13.1-transformers4.26.0-gpu-py39-cu117-ubuntu20.04",
+                    "cpu_image_uri": "867930986793.dkr.us-west-2.amazonaws.com/cpu-blah",
+                }
+            },
+            "variants": {
+                "p2": {"regional_properties": {"image_uri": "$gpu_image_uri"}},
+                "p3": {"regional_properties": {"image_uri": "$gpu_image_uri"}},
+                "p4": {"regional_properties": {"image_uri": "$gpu_image_uri"}},
+                "g4dn": {"regional_properties": {"image_uri": "$gpu_image_uri"}},
+                "m2": {"regional_properties": {"image_uri": "$cpu_image_uri"}},
+                "c2": {"regional_properties": {"image_uri": "$cpu_image_uri"}},
+                "ml.g5.48xlarge": {
+                    "properties": {"environment_variables": {"TENSOR_PARALLEL_DEGREE": "8"}}
+                },
+                "ml.g5.12xlarge": {
+                    "properties": {"environment_variables": {"TENSOR_PARALLEL_DEGREE": "4"}}
+                },
+            },
+        },
+        "training_ecr_specs": {
+            "framework": "pytorch",
+            "framework_version": "1.5.0",
+            "py_version": "py3",
+        },
+        "training_instance_type_variants": None,
+        "hosting_artifact_key": "pytorch-infer/infer-pytorch-ic-mobilenet-v2.tar.gz",
+        "training_artifact_key": "pytorch-training/train-pytorch-ic-mobilenet-v2.tar.gz",
+        "hosting_script_key": "source-directory-tarballs/pytorch/inference/ic/v1.0.0/sourcedir.tar.gz",
+        "training_script_key": "source-directory-tarballs/pytorch/transfer_learning/ic/v1.0.0/sourcedir.tar.gz",
+        "training_prepacked_script_key": None,
+        "hosting_prepacked_artifact_key": None,
+        "training_model_package_artifact_uris": None,
+        "deprecate_warn_message": None,
+        "deprecated_message": None,
+        "hosting_model_package_arns": None,
+        "hosting_eula_key": None,
+        "hyperparameters": [
+            {
+                "name": "epochs",
+                "type": "int",
+                "default": 3,
+                "min": 1,
+                "max": 1000,
+                "scope": "algorithm",
+            },
+            {
+                "name": "adam-learning-rate",
+                "type": "float",
+                "default": 0.05,
+                "min": 1e-08,
+                "max": 1,
+                "scope": "algorithm",
+            },
+            {
+                "name": "batch-size",
+                "type": "int",
+                "default": 4,
+                "min": 1,
+                "max": 1024,
+                "scope": "algorithm",
+            },
+            {
+                "name": "sagemaker_submit_directory",
+                "type": "text",
+                "default": "/opt/ml/input/data/code/sourcedir.tar.gz",
+                "scope": "container",
+            },
+            {
+                "name": "sagemaker_program",
+                "type": "text",
+                "default": "transfer_learning.py",
+                "scope": "container",
+            },
+            {
+                "name": "sagemaker_container_log_level",
+                "type": "text",
+                "default": "20",
+                "scope": "container",
+            },
+        ],
+        "inference_environment_variables": [
+            {
+                "name": "SAGEMAKER_PROGRAM",
+                "type": "text",
+                "default": "inference.py",
+                "scope": "container",
+                "required_for_model_class": True,
+            },
+            {
+                "name": "SAGEMAKER_SUBMIT_DIRECTORY",
+                "type": "text",
+                "default": "/opt/ml/model/code",
+                "scope": "container",
+                "required_for_model_class": False,
+            },
+            {
+                "name": "SAGEMAKER_CONTAINER_LOG_LEVEL",
+                "type": "text",
+                "default": "20",
+                "scope": "container",
+                "required_for_model_class": False,
+            },
+            {
+                "name": "SAGEMAKER_MODEL_SERVER_TIMEOUT",
+                "type": "text",
+                "default": "3600",
+                "scope": "container",
+                "required_for_model_class": False,
+            },
+            {
+                "name": "ENDPOINT_SERVER_TIMEOUT",
+                "type": "int",
+                "default": 3600,
+                "scope": "container",
+                "required_for_model_class": True,
+            },
+            {
+                "name": "MODEL_CACHE_ROOT",
+                "type": "text",
+                "default": "/opt/ml/model",
+                "scope": "container",
+                "required_for_model_class": True,
+            },
+            {
+                "name": "SAGEMAKER_ENV",
+                "type": "text",
+                "default": "1",
+                "scope": "container",
+                "required_for_model_class": True,
+            },
+            {
+                "name": "SAGEMAKER_MODEL_SERVER_WORKERS",
+                "type": "int",
+                "default": 1,
+                "scope": "container",
+                "required_for_model_class": True,
+            },
+        ],
+        "inference_vulnerable": False,
+        "inference_dependencies": [],
+        "inference_vulnerabilities": [],
+        "training_vulnerable": False,
+        "training_dependencies": [],
+        "training_vulnerabilities": [],
+        "deprecated": False,
+        "default_inference_instance_type": "ml.p2.xlarge",
+        "supported_inference_instance_types": [
+            "ml.p2.xlarge",
+            "ml.p3.2xlarge",
+            "ml.g4dn.xlarge",
+            "ml.m5.large",
+            "ml.m5.xlarge",
+            "ml.c5.xlarge",
+            "ml.c5.2xlarge",
+        ],
+        "default_training_instance_type": "ml.p3.2xlarge",
+        "supported_training_instance_types": [
+            "ml.p3.2xlarge",
+            "ml.p2.xlarge",
+            "ml.g4dn.2xlarge",
+            "ml.m5.xlarge",
+            "ml.c5.2xlarge",
+        ],
+        "hosting_use_script_uri": True,
+        "metrics": [{"Regex": "val_accuracy: ([0-9\\.]+)", "Name": "pytorch-ic:val-accuracy"}],
+        "model_kwargs": {"some-model-kwarg-key": "some-model-kwarg-value"},
+        "deploy_kwargs": {"some-model-deploy-kwarg-key": "some-model-deploy-kwarg-value"},
+        "estimator_kwargs": {
+            "encrypt_inter_container_traffic": True,
+        },
+        "fit_kwargs": {"some-estimator-fit-key": "some-estimator-fit-value"},
+        "predictor_specs": {
+            "supported_content_types": ["application/x-image"],
+            "supported_accept_types": ["application/json;verbose", "application/json"],
+            "default_content_type": "application/x-image",
+            "default_accept_type": "application/json",
+        },
+        "inference_volume_size": 123,
+        "training_volume_size": 456,
+        "inference_enable_network_isolation": True,
+        "training_enable_network_isolation": False,
+        "resource_name_base": "dfsdfsds",
+    },
     "js-model-package-arn": {
         "model_id": "meta-textgeneration-llama-2-7b-f",
         "url": "https://ai.meta.com/resources/models-and-libraries/llama-downloads/",
@@ -958,6 +1317,308 @@ SPECIAL_MODEL_SPECS_DICT = {
             "default_accept_type": "application/json",
         },
         "resource_name_base": "blahblahblah",
+        "hosting_instance_type_variants": {
+            "regional_aliases": {
+                "af-south-1": {
+                    "cpu_ecr_uri_1": "626614931356.dkr.ecr.af-south-1"
+                    ".amazonaws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "626614931356.dkr.ecr.af-south-1"
+                    ".amazonaws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "ap-east-1": {
+                    "cpu_ecr_uri_1": "871362719292.dkr.ecr.ap-east-1."
+                    "amazonaws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "871362719292.dkr.ecr.ap-east-1."
+                    "amazonaws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "ap-northeast-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.ap-northeast-"
+                    "1.amazonaws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.ap-northeast-"
+                    "1.amazonaws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "ap-northeast-2": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.ap-northeast-2"
+                    ".amazonaws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.ap-northeast-2"
+                    ".amazonaws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "ap-south-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.ap-south-1.ama"
+                    "zonaws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.ap-south-1.amazo"
+                    "naws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "ap-southeast-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.ap-southeast-1.amazo"
+                    "naws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.ap-southeast-1.a"
+                    "mazonaws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "ap-southeast-2": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.ap-southeast-2.am"
+                    "azonaws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.ap-southeast-2.amazon"
+                    "aws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "ca-central-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.ca-central-1.amaz"
+                    "onaws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.ca-central-1.amazon"
+                    "aws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "cn-north-1": {
+                    "cpu_ecr_uri_1": "727897471807.dkr.ecr.cn-north-1.amazonaw"
+                    "s.com.cn/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "727897471807.dkr.ecr.cn-north-1.amazonaws"
+                    ".com.cn/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "eu-central-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.eu-central-1.amazona"
+                    "ws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.eu-central-1.amazonaw"
+                    "s.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "eu-north-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.eu-north-1.amazona"
+                    "ws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.eu-north-1.amazona"
+                    "ws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "eu-south-1": {
+                    "cpu_ecr_uri_1": "692866216735.dkr.ecr.eu-south-1.amaz"
+                    "onaws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "692866216735.dkr.ecr.eu-south-1.amazo"
+                    "naws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "eu-west-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.eu-west-1."
+                    "amazonaws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.eu-west-1.ama"
+                    "zonaws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "eu-west-2": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.eu-west-2.amazona"
+                    "ws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.eu-west-2.amazonaw"
+                    "s.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "eu-west-3": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.eu-west-3.amazonaws"
+                    ".com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.eu-west-3.amaz"
+                    "onaws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "me-south-1": {
+                    "cpu_ecr_uri_1": "217643126080.dkr.ecr.me-south-1.amaz"
+                    "onaws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "217643126080.dkr.ecr.me-south-1.amazo"
+                    "naws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "sa-east-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.sa-east-1.amaz"
+                    "onaws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.sa-east-1.ama"
+                    "zonaws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "us-east-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.us-east-1.ama"
+                    "zonaws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.us-east-1.am"
+                    "azonaws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "us-east-2": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.us-east-2.amazo"
+                    "naws.com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.us-east-2.amazon"
+                    "aws.com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "us-west-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.us-west-1.amazonaws."
+                    "com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.us-west-1.amazonaws."
+                    "com/autogluon-inference:0.4.3-gpu-py38",
+                },
+                "us-west-2": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.us-west-2.amazonaws"
+                    ".com/autogluon-inference:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.us-west-2.amazonaws."
+                    "com/autogluon-inference:0.4.3-gpu-py38",
+                },
+            },
+            "variants": {
+                "c4": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "c5": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "c5d": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "c5n": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "c6i": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "g4dn": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "g5": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "local": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "local_gpu": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "m4": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "m5": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "m5d": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "p2": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "p3": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "p3dn": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "p4d": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "p4de": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "p5": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "r5": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "r5d": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "t2": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "t3": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+            },
+        },
+        "training_instance_type_variants": {
+            "regional_aliases": {
+                "af-south-1": {
+                    "cpu_ecr_uri_1": "626614931356.dkr.ecr.af-south"
+                    "-1.amazonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "626614931356.dkr.ecr.af-south-1.amaz"
+                    "naws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "ap-east-1": {
+                    "cpu_ecr_uri_1": "871362719292.dkr.ecr.ap-east-"
+                    "1.amazonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "871362719292.dkr.ecr.ap-east-1.amaz"
+                    "onaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "ap-northeast-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.ap-northeast-1.ama"
+                    "zonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.ap-northeast-1.a"
+                    "mazonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "ap-northeast-2": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.ap-northeast-2."
+                    "amazonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.ap-northeast-2."
+                    "amazonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "ap-south-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.ap-sou"
+                    "th-1.amazonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.ap-south-1.ama"
+                    "zonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "ap-southeast-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.ap-southeast-"
+                    "1.amazonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.ap-southeast"
+                    "-1.amazonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "ap-southeast-2": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.ap-southeast"
+                    "-2.amazonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.ap-southeast-2."
+                    "amazonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "ca-central-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.ca-central-1.a"
+                    "mazonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.ca-central-1.am"
+                    "azonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "eu-central-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.eu-central-1.a"
+                    "mazonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.eu-central-1.am"
+                    "azonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "eu-north-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.eu-north-1.am"
+                    "azonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.eu-north-1.amazon"
+                    "aws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "eu-south-1": {
+                    "cpu_ecr_uri_1": "692866216735.dkr.ecr.eu-south-1.amaz"
+                    "onaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "692866216735.dkr.ecr.eu-south-1.ama"
+                    "zonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "eu-west-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.eu-west-1.amaz"
+                    "onaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.eu-west-1.amazo"
+                    "naws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "eu-west-2": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.eu-west-2.am"
+                    "azonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.eu-west-2.am"
+                    "azonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "eu-west-3": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.eu-west-3."
+                    "amazonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.eu-west-3."
+                    "amazonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "me-south-1": {
+                    "cpu_ecr_uri_1": "217643126080.dkr.ecr.me-sout"
+                    "h-1.amazonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "217643126080.dkr.ecr.me-south-1."
+                    "amazonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "sa-east-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.sa-east-1."
+                    "amazonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.sa-east-1"
+                    ".amazonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "us-east-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.us-east-1."
+                    "amazonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.us-east-1."
+                    "amazonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "us-east-2": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.us-east-2"
+                    ".amazonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.us-east-"
+                    "2.amazonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "us-west-1": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.us-west"
+                    "-1.amazonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.us-wes"
+                    "t-1.amazonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+                "us-west-2": {
+                    "cpu_ecr_uri_1": "763104351884.dkr.ecr.us-west"
+                    "-2.amazonaws.com/autogluon-training:0.4.3-cpu-py38",
+                    "gpu_ecr_uri_2": "763104351884.dkr.ecr.us-w"
+                    "est-2.amazonaws.com/autogluon-training:0.4.3-gpu-py38",
+                },
+            },
+            "variants": {
+                "c4": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "c5": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "c5d": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "c5n": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "c6i": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "g4dn": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "g5": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "local": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "local_gpu": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "m4": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "m5": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "m5d": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "p2": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "p3": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "p3dn": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "p4d": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "p4de": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "p5": {"regional_properties": {"image_uri": "$gpu_ecr_uri_2"}},
+                "r5": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "r5d": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "t2": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+                "t3": {"regional_properties": {"image_uri": "$cpu_ecr_uri_1"}},
+            },
+        },
     },
     "predictor-specs-model": {
         "model_id": "huggingface-text2text-flan-t5-xxl-fp16",
@@ -2447,11 +3108,13 @@ BASE_SPEC = {
         "framework_version": "1.5.0",
         "py_version": "py3",
     },
+    "hosting_instance_type_variants": None,
     "training_ecr_specs": {
         "framework": "pytorch",
         "framework_version": "1.5.0",
         "py_version": "py3",
     },
+    "training_instance_type_variants": None,
     "hosting_artifact_key": "pytorch-infer/infer-pytorch-ic-mobilenet-v2.tar.gz",
     "training_artifact_key": "pytorch-training/train-pytorch-ic-mobilenet-v2.tar.gz",
     "hosting_script_key": "source-directory-tarballs/pytorch/inference/ic/v1.0.0/sourcedir.tar.gz",

--- a/tests/unit/sagemaker/jumpstart/test_types.py
+++ b/tests/unit/sagemaker/jumpstart/test_types.py
@@ -15,10 +15,53 @@ import copy
 from sagemaker.jumpstart.types import (
     JumpStartECRSpecs,
     JumpStartHyperparameter,
+    JumpStartInstanceTypeVariants,
     JumpStartModelSpecs,
     JumpStartModelHeader,
 )
 from tests.unit.sagemaker.jumpstart.constants import BASE_SPEC
+
+INSTANCE_TYPE_VARIANT = JumpStartInstanceTypeVariants(
+    {
+        "regional_aliases": {
+            "us-west-2": {
+                "gpu_image_uri": "763104351884.dkr.ecr.us-west-2.amazonaws.com/"
+                "huggingface-pytorch-inference:1.13.1-transformers4.26.0-gpu-py39-cu117-ubuntu20.04",
+                "gpu_image_uri_2": "763104351884.dkr.ecr.us-west-2.amazonaws.com/stud-gpu",
+                "cpu_image_uri": "867930986793.dkr.us-west-2.amazonaws.com/cpu-blah",
+            }
+        },
+        "variants": {
+            "p2": {"regional_properties": {"image_uri": "$gpu_image_uri"}},
+            "p3": {"regional_properties": {"image_uri": "$gpu_image_uri"}},
+            "ml.p3.200xlarge": {"regional_properties": {"image_uri": "$gpu_image_uri_2"}},
+            "p4": {"regional_properties": {"image_uri": "$gpu_image_uri"}},
+            "g4dn": {"regional_properties": {"image_uri": "$gpu_image_uri"}},
+            "g9": {"regional_properties": {"image_uri": "$gpu_image_uri"}},
+            "m2": {
+                "regional_properties": {"image_uri": "$cpu_image_uri"},
+                "properties": {"environment_variables": {"TENSOR_PARALLEL_DEGREE": "400"}},
+            },
+            "c2": {"regional_properties": {"image_uri": "$cpu_image_uri"}},
+            "local": {"regional_properties": {"image_uri": "$cpu_image_uri"}},
+            "ml.g5.48xlarge": {
+                "properties": {"environment_variables": {"TENSOR_PARALLEL_DEGREE": "8"}}
+            },
+            "ml.g5.12xlarge": {
+                "properties": {"environment_variables": {"TENSOR_PARALLEL_DEGREE": "4"}}
+            },
+            "g5": {
+                "properties": {
+                    "environment_variables": {"TENSOR_PARALLEL_DEGREE": "4", "JOHN": "DOE"}
+                }
+            },
+            "ml.g9.12xlarge": {
+                "properties": {"environment_variables": {"TENSOR_PARALLEL_DEGREE": "4"}}
+            },
+            "g6": {"properties": {"environment_variables": {"BLAH": "4"}}},
+        },
+    }
+)
 
 
 def test_jumpstart_model_header():
@@ -155,3 +198,95 @@ def test_jumpstart_model_specs():
 
     specs3 = copy.deepcopy(specs1)
     assert specs3 == specs1
+
+
+def test_jumpstart_image_uri_instance_variants():
+
+    assert (
+        INSTANCE_TYPE_VARIANT.get_image_uri(instance_type="ml.p3.200xlarge", region="us-west-2")
+        == "763104351884.dkr.ecr.us-west-2.amazonaws.com/stud-gpu"
+    )
+
+    assert (
+        INSTANCE_TYPE_VARIANT.get_image_uri(instance_type="ml.g9.12xlarge", region="us-west-2")
+        == "763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-inference:"
+        "1.13.1-transformers4.26.0-gpu-py39-cu117-ubuntu20.04"
+    )
+
+    assert (
+        INSTANCE_TYPE_VARIANT.get_image_uri(instance_type="ml.p3.2xlarge", region="us-west-2")
+        == "763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-inference:"
+        "1.13.1-transformers4.26.0-gpu-py39-cu117-ubuntu20.04"
+    )
+
+    assert (
+        INSTANCE_TYPE_VARIANT.get_image_uri(instance_type="ml.g4dn.2xlarge", region="us-west-2")
+        == "763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-inference:"
+        "1.13.1-transformers4.26.0-gpu-py39-cu117-ubuntu20.04"
+    )
+
+    assert (
+        INSTANCE_TYPE_VARIANT.get_image_uri(instance_type="ml.c2.xlarge", region="us-west-2")
+        == "867930986793.dkr.us-west-2.amazonaws.com/cpu-blah"
+    )
+
+    assert (
+        INSTANCE_TYPE_VARIANT.get_image_uri(instance_type="local", region="us-west-2")
+        == "867930986793.dkr.us-west-2.amazonaws.com/cpu-blah"
+    )
+
+    assert (
+        INSTANCE_TYPE_VARIANT.get_image_uri(instance_type="local_gpu", region="us-west-2") is None
+    )
+
+    assert (
+        INSTANCE_TYPE_VARIANT.get_image_uri(instance_type="ml.g5.12xlarge", region="us-west-2")
+        is None
+    )
+
+    assert (
+        INSTANCE_TYPE_VARIANT.get_image_uri(instance_type="ml.c3.xlarge", region="us-west-2")
+        is None
+    )
+
+    assert (
+        INSTANCE_TYPE_VARIANT.get_image_uri(instance_type="ml.c2.xlarge", region="us-east-2000")
+        is None
+    )
+
+    assert (
+        INSTANCE_TYPE_VARIANT.get_image_uri(instance_type="ml.c3.xlarge", region="us-east-2000")
+        is None
+    )
+
+
+def test_jumpstart_environment_variables_instance_variants():
+    assert INSTANCE_TYPE_VARIANT.get_instance_specific_environment_variables(
+        instance_type="ml.g9.12xlarge"
+    ) == {"TENSOR_PARALLEL_DEGREE": "4"}
+
+    assert INSTANCE_TYPE_VARIANT.get_instance_specific_environment_variables(
+        instance_type="ml.g5.48xlarge"
+    ) == {"TENSOR_PARALLEL_DEGREE": "8", "JOHN": "DOE"}
+
+    assert INSTANCE_TYPE_VARIANT.get_instance_specific_environment_variables(
+        instance_type="ml.m2.48xlarge"
+    ) == {"TENSOR_PARALLEL_DEGREE": "400"}
+
+    assert INSTANCE_TYPE_VARIANT.get_instance_specific_environment_variables(
+        instance_type="ml.g6.48xlarge"
+    ) == {"BLAH": "4"}
+
+    assert (
+        INSTANCE_TYPE_VARIANT.get_instance_specific_environment_variables(
+            instance_type="ml.p2.xlarge"
+        )
+        == {}
+    )
+
+    assert (
+        INSTANCE_TYPE_VARIANT.get_instance_specific_environment_variables(
+            instance_type="safh8ads9fhsad89fh"
+        )
+        == {}
+    )

--- a/tests/unit/sagemaker/monitor/test_cron_expression_generator.py
+++ b/tests/unit/sagemaker/monitor/test_cron_expression_generator.py
@@ -36,3 +36,7 @@ def test_cron_expression_generator_daily_every_x_hours_returns_expected_value_wh
         CronExpressionGenerator.daily_every_x_hours(hour_interval=7, starting_hour=8)
         == "cron(0 8/7 ? * * *)"
     )
+
+
+def test_cron_expression_generator_now():
+    assert CronExpressionGenerator.now() == "NOW"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -33,6 +33,7 @@ import sagemaker
 from sagemaker.experiments._run_context import _RunContext
 from sagemaker.session_settings import SessionSettings
 from sagemaker.utils import (
+    get_instance_type_family,
     retry_with_backoff,
     check_and_get_run_experiment_config,
     get_sagemaker_config_value,
@@ -1721,3 +1722,20 @@ class TestVolumeSizeSupported(TestCase):
 
         with pytest.raises(ValueError):
             volume_size_supported({})
+
+    def test_instance_family_from_full_instance_type(self):
+
+        instance_type_to_family_test_dict = {
+            "ml.p3.xlarge": "p3",
+            "ml.inf1.4xlarge": "inf1",
+            "ml.afbsadjfbasfb.sdkjfnsa": "afbsadjfbasfb",
+            "ml_fdsfsdf.xlarge": "fdsfsdf",
+            "ml_c2.4xlarge": "c2",
+            "sdfasfdda": "",
+            "local": "",
+            "c2.xlarge": "",
+            "": "",
+        }
+
+        for instance_type, family in instance_type_to_family_test_dict.items():
+            self.assertEqual(family, get_instance_type_family(instance_type))

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,8 @@ markers =
     canary_quick
     cron
     local_mode
+    slow_test
+    release
     timeout: mark a test as a timeout.
 
 [testenv]


### PR DESCRIPTION
Co-authored-by: Keshav Chandak <chakesh@amazon.com>*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
